### PR TITLE
fix(ci): enable buildx cache for preview updates

### DIFF
--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -95,8 +95,13 @@ jobs:
           tags: |
             type=raw,value=alpha-pr-${{ github.event.client_payload.pr_number }}
             type=raw,value=${{ steps.get_sha.outputs.sha }}
-      - name: ⚙️ Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: ⚙️ Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
+      - name: ⚙️ Expose GitHub runtime for Buildx cache
+        uses: crazy-max/ghaction-github-runtime@v3
 
       - name: 📦 Build and push
         run: |


### PR DESCRIPTION
## Summary
- replace the preview cloud update QEMU setup with an explicit Buildx builder
- use the docker-container driver so the existing gha cache flags from teable-ee can be consumed

## Why
The preview workflow already passes `--cache-from/--cache-to type=gha`, but the job still used the default docker driver. That prevented the preview update workflow from reliably benefiting from the remote BuildKit cache.

## Validation
- reviewed the workflow to confirm preview builds call `scripts/build-image.mjs` with the existing cache flags from teable-ee
- switched the workflow to `docker/setup-buildx-action@v3` with `driver: docker-container`
- kept the change scoped to `.github/workflows/manual-preview-cloud-update.yml` only