### PR TITLE
ci: ensure byodb migration worker deployment

### DIFF
--- a/.github/scripts/ensure-byodb-migration-worker.sh
+++ b/.github/scripts/ensure-byodb-migration-worker.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local key="$1"
+  if [ -z "${!key:-}" ]; then
+    echo "::error::Missing required env ${key}"
+    exit 1
+  fi
+}
+
+if [ -z "${KUBE_NAMESPACE:-}" ] && [ -n "${NAMESPACE:-}" ]; then
+  KUBE_NAMESPACE="ns-${NAMESPACE}"
+fi
+
+require_env APP_DEPLOYMENT
+
+WORKER_DEPLOYMENT="${WORKER_DEPLOYMENT:-${APP_DEPLOYMENT}-byodb-migration-worker}"
+WORKER_CONTAINER="${WORKER_CONTAINER:-byodb-migration-worker}"
+WORKER_ARG="${WORKER_ARG:-byodb-migration-worker-skip-migrate}"
+WORKER_REPLICAS="${WORKER_REPLICAS:-1}"
+WORKER_TERMINATION_GRACE_SECONDS="${WORKER_TERMINATION_GRACE_SECONDS:-30}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-300s}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+if [ -n "${KUBE_CONFIG:-}" ]; then
+  mkdir -p ~/.kube
+  echo "${KUBE_CONFIG}" | base64 -d > ~/.kube/config
+fi
+
+kubectl_namespace_args=()
+if [ -n "${KUBE_NAMESPACE:-}" ]; then
+  kubectl_namespace_args=(-n "${KUBE_NAMESPACE}")
+fi
+
+kubectl "${kubectl_namespace_args[@]}" get deployment "${APP_DEPLOYMENT}" -o json > "${tmp_dir}/app.json"
+
+APP_CONTAINER="${APP_CONTAINER:-}"
+if [ -z "${APP_CONTAINER}" ]; then
+  APP_CONTAINER="$(jq -r '.spec.template.spec.containers[0].name' "${tmp_dir}/app.json")"
+fi
+
+if ! jq -e --arg container "${APP_CONTAINER}" \
+  '.spec.template.spec.containers[] | select(.name == $container)' \
+  "${tmp_dir}/app.json" >/dev/null; then
+  echo "::error::Container ${APP_CONTAINER} was not found in deployment ${APP_DEPLOYMENT}"
+  exit 1
+fi
+
+WORKER_IMAGE="${WORKER_IMAGE:-}"
+if [ -z "${WORKER_IMAGE}" ]; then
+  WORKER_IMAGE="$(jq -r --arg container "${APP_CONTAINER}" \
+    '.spec.template.spec.containers[] | select(.name == $container) | .image' \
+    "${tmp_dir}/app.json")"
+fi
+
+WORKER_OTEL_SERVICE_NAME="${WORKER_OTEL_SERVICE_NAME:-${WORKER_DEPLOYMENT}}"
+
+jq \
+  --arg appContainer "${APP_CONTAINER}" \
+  --arg workerDeployment "${WORKER_DEPLOYMENT}" \
+  --arg workerContainer "${WORKER_CONTAINER}" \
+  --arg workerImage "${WORKER_IMAGE}" \
+  --arg workerArg "${WORKER_ARG}" \
+  --arg workerReplicas "${WORKER_REPLICAS}" \
+  --arg terminationGraceSeconds "${WORKER_TERMINATION_GRACE_SECONDS}" \
+  --arg otelServiceName "${WORKER_OTEL_SERVICE_NAME}" \
+  '
+  def worker_env:
+    [
+      {
+        name: "BYODB_SPACE_DATA_DB_MIGRATION_WORKER_ID",
+        valueFrom: { fieldRef: { fieldPath: "metadata.name" } }
+      }
+    ] + if $otelServiceName == "" then [] else [{ name: "OTEL_SERVICE_NAME", value: $otelServiceName }] end;
+
+  def without_worker_env:
+    map(select(.name != "BYODB_SPACE_DATA_DB_MIGRATION_WORKER_ID" and .name != "OTEL_SERVICE_NAME"));
+
+  (.spec.template.spec.containers[] | select(.name == $appContainer)) as $appContainerSpec
+  | {
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: {
+        name: $workerDeployment,
+        namespace: .metadata.namespace,
+        labels: ((.metadata.labels // {}) + {
+          app: $workerDeployment,
+          "app.kubernetes.io/component": "byodb-migration-worker"
+        }),
+        annotations: ((.metadata.annotations // {}) + {
+          originImageName: $workerImage
+        })
+      },
+      spec: {
+        replicas: ($workerReplicas | tonumber),
+        revisionHistoryLimit: (.spec.revisionHistoryLimit // 1),
+        minReadySeconds: (.spec.minReadySeconds // 0),
+        selector: {
+          matchLabels: {
+            app: $workerDeployment
+          }
+        },
+        template: {
+          metadata: {
+            labels: ((.spec.template.metadata.labels // {}) + {
+              app: $workerDeployment,
+              "app.kubernetes.io/component": "byodb-migration-worker"
+            }),
+            annotations: (.spec.template.metadata.annotations // {})
+          },
+          spec: (
+            .spec.template.spec
+            | del(.containers, .initContainers)
+            | .terminationGracePeriodSeconds = ($terminationGraceSeconds | tonumber)
+            | .containers = [
+                (
+                  $appContainerSpec
+                  | .name = $workerContainer
+                  | .image = $workerImage
+                  | .args = [$workerArg]
+                  | del(.command, .ports, .livenessProbe, .readinessProbe, .startupProbe, .lifecycle)
+                  | .env = (((.env // []) | without_worker_env) + worker_env)
+                )
+              ]
+          )
+        }
+      }
+    }
+  ' "${tmp_dir}/app.json" > "${tmp_dir}/byodb-migration-worker.json"
+
+kubectl "${kubectl_namespace_args[@]}" apply -f "${tmp_dir}/byodb-migration-worker.json"
+kubectl "${kubectl_namespace_args[@]}" rollout status "deployment/${WORKER_DEPLOYMENT}" --timeout="${ROLLOUT_TIMEOUT}"

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -142,6 +142,12 @@ jobs:
             console.log('PR labels:', labels.join(', '));
             console.log('Enable tracing:', enableTracing);
 
+      - name: Checkout deployment tooling
+        if: steps.check_deploy.outcome == 'success'
+        uses: actions/checkout@v4
+        with:
+          path: deployment-tooling
+
       # --- Fallback: full create if deployment does not exist ---
       - name: Checkout repository (fallback create)
         if: steps.check_deploy.outcome == 'failure'
@@ -256,6 +262,24 @@ jobs:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: apply -f deploy.yaml
+
+      - name: Checkout deployment tooling (fallback create)
+        if: steps.check_deploy.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          path: deployment-tooling
+
+      - name: Ensure BYODB migration worker deployment (fallback create)
+        if: steps.check_deploy.outcome == 'failure'
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          NAMESPACE: ${{ env.NAMESPACE }}
+          APP_DEPLOYMENT: teable-${{ env.INSTANCE_NAME }}
+          APP_CONTAINER: teable-${{ env.INSTANCE_NAME }}
+          WORKER_DEPLOYMENT: teable-${{ env.INSTANCE_NAME }}-byodb-migration-worker
+          WORKER_IMAGE: registry.cn-shenzhen.aliyuncs.com/teable/teable-ee-preview:${{ needs.build-push.outputs.main_commit_sha }}
+          WORKER_OTEL_SERVICE_NAME: teable-preview-${{ env.INSTANCE_NAME }}-byodb-migration-worker
+        run: deployment-tooling/.github/scripts/ensure-byodb-migration-worker.sh
 
       # --- Normal update path if deployment exists ---
       - name: Ensure enterprise license env
@@ -461,6 +485,18 @@ jobs:
           fi
 
           rm -f ~/.kube/config
+
+      - name: Ensure BYODB migration worker deployment
+        if: steps.check_deploy.outcome == 'success'
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          NAMESPACE: ${{ env.NAMESPACE }}
+          APP_DEPLOYMENT: teable-${{ env.INSTANCE_NAME }}
+          APP_CONTAINER: teable-${{ env.INSTANCE_NAME }}
+          WORKER_DEPLOYMENT: teable-${{ env.INSTANCE_NAME }}-byodb-migration-worker
+          WORKER_IMAGE: registry.cn-shenzhen.aliyuncs.com/teable/teable-ee-preview:${{ needs.build-push.outputs.main_commit_sha }}
+          WORKER_OTEL_SERVICE_NAME: teable-preview-${{ env.INSTANCE_NAME }}-byodb-migration-worker
+        run: deployment-tooling/.github/scripts/ensure-byodb-migration-worker.sh
 
       - name: Rollout sandbox status
         uses: actions-hub/kubectl@master

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -248,6 +248,22 @@ jobs:
         with:
           args: apply -f deploy.yaml
 
+      - name: Checkout deployment tooling
+        uses: actions/checkout@v4
+        with:
+          path: deployment-tooling
+
+      - name: Ensure BYODB migration worker deployment
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          NAMESPACE: ${{ env.NAMESPACE }}
+          APP_DEPLOYMENT: teable-${{ env.INSTANCE_NAME }}
+          APP_CONTAINER: teable-${{ env.INSTANCE_NAME }}
+          WORKER_DEPLOYMENT: teable-${{ env.INSTANCE_NAME }}-byodb-migration-worker
+          WORKER_IMAGE: registry.cn-shenzhen.aliyuncs.com/teable/teable-ee-preview:${{ steps.get_sha.outputs.sha }}
+          WORKER_OTEL_SERVICE_NAME: teable-preview-${{ env.INSTANCE_NAME }}-byodb-migration-worker
+        run: deployment-tooling/.github/scripts/ensure-byodb-migration-worker.sh
+
       - name: Rollout status
         uses: actions-hub/kubectl@master
         env:

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -172,6 +172,16 @@ jobs:
         with:
           args: annotate deployment/teable-cloud originImageName="registry.cn-shenzhen.aliyuncs.com/teable/teable-cloud:${{ inputs.image_tag }}" --overwrite
 
+      - name: Ensure BYODB migration worker deployment
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          APP_DEPLOYMENT: teable-cloud
+          APP_CONTAINER: teable-cloud
+          WORKER_DEPLOYMENT: teable-cloud-byodb-migration-worker
+          WORKER_IMAGE: registry.cn-shenzhen.aliyuncs.com/teable/teable-cloud:${{ inputs.image_tag }}
+          WORKER_OTEL_SERVICE_NAME: teable-cloud-byodb-migration-worker
+        run: .github/scripts/ensure-byodb-migration-worker.sh
+
       - name: Rollout status
         uses: actions-hub/kubectl@master
         env:


### PR DESCRIPTION
## Summary

- add reusable Kubernetes deployment script for the BYODB migration worker
- wire EE preview create/update flows to ensure the worker deployment exists and rolls out
- wire Sealos production deploy to reuse the same worker deployment logic

## Validation

- `bash -n .github/scripts/ensure-byodb-migration-worker.sh`
- fake kubectl dry-run for generated worker deployment shape
- YAML parse check for touched workflows
- `git diff --check`