### PR TITLE
feat: ensure BYODB migration worker on ECS deploy

### DIFF
--- a/.github/scripts/ensure-byodb-migration-worker-ecs.sh
+++ b/.github/scripts/ensure-byodb-migration-worker-ecs.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local key="$1"
+  if [ -z "${!key:-}" ]; then
+    echo "::error::Missing required env ${key}"
+    exit 1
+  fi
+}
+
+require_env ECS_CLUSTER
+require_env APP_SERVICE
+require_env APP_TASK_DEFINITION_FILE
+
+AWS_REGION="${AWS_REGION:-us-west-2}"
+APP_CONTAINER="${APP_CONTAINER:-teable}"
+WORKER_TASK_FAMILY="${WORKER_TASK_FAMILY:-teable-byodb-migration-worker}"
+WORKER_SERVICE="${WORKER_SERVICE:-teable-byodb-migration-worker}"
+WORKER_CONTAINER="${WORKER_CONTAINER:-teable}"
+WORKER_COMMAND="${WORKER_COMMAND:-byodb-migration-worker-skip-migrate}"
+WORKER_DESIRED_COUNT="${WORKER_DESIRED_COUNT:-1}"
+WORKER_TASK_CPU="${WORKER_TASK_CPU:-512}"
+WORKER_TASK_MEMORY="${WORKER_TASK_MEMORY:-1024}"
+WORKER_OTEL_SERVICE_NAME="${WORKER_OTEL_SERVICE_NAME:-${WORKER_SERVICE}}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+aws ecs describe-services \
+  --cluster "${ECS_CLUSTER}" \
+  --services "${APP_SERVICE}" \
+  --include TAGS \
+  --region "${AWS_REGION}" \
+  --query 'services[0]' > "${tmp_dir}/app-service.json"
+
+if ! jq -e '.serviceName != null' "${tmp_dir}/app-service.json" >/dev/null; then
+  echo "::error::ECS service ${APP_SERVICE} was not found in cluster ${ECS_CLUSTER}"
+  exit 1
+fi
+
+if ! jq -e --arg appContainer "${APP_CONTAINER}" \
+  '.containerDefinitions[] | select(.name == $appContainer)' \
+  "${APP_TASK_DEFINITION_FILE}" >/dev/null; then
+  echo "::error::Container ${APP_CONTAINER} was not found in task definition ${APP_TASK_DEFINITION_FILE}"
+  exit 1
+fi
+
+jq \
+  --arg appContainer "${APP_CONTAINER}" \
+  --arg workerTaskFamily "${WORKER_TASK_FAMILY}" \
+  --arg workerContainer "${WORKER_CONTAINER}" \
+  --arg workerCommand "${WORKER_COMMAND}" \
+  --arg workerCpu "${WORKER_TASK_CPU}" \
+  --arg workerMemory "${WORKER_TASK_MEMORY}" \
+  --arg workerId "${WORKER_SERVICE}" \
+  --arg otelServiceName "${WORKER_OTEL_SERVICE_NAME}" \
+  '
+  def registration_fields:
+    {
+      family,
+      taskRoleArn,
+      executionRoleArn,
+      networkMode,
+      containerDefinitions,
+      volumes,
+      placementConstraints,
+      requiresCompatibilities,
+      cpu,
+      memory,
+      runtimePlatform,
+      ephemeralStorage,
+      proxyConfiguration,
+      inferenceAccelerators,
+      ipcMode,
+      pidMode
+    }
+    | with_entries(select(.value != null and .value != []));
+
+  def upsert_env($name; $value):
+    map(select(.name != $name)) + [{ name: $name, value: $value }];
+
+  (.containerDefinitions[] | select(.name == $appContainer)) as $appContainerSpec
+  | registration_fields
+  | .family = $workerTaskFamily
+  | .cpu = $workerCpu
+  | .memory = $workerMemory
+  | .containerDefinitions = [
+      (
+        $appContainerSpec
+        | .name = $workerContainer
+        | .command = [$workerCommand]
+        | del(.portMappings, .healthCheck, .dependsOn)
+        | .environment = (
+            ((.environment // [])
+              | upsert_env("BYODB_SPACE_DATA_DB_MIGRATION_WORKER_ID"; $workerId)
+              | upsert_env("OTEL_SERVICE_NAME"; $otelServiceName))
+          )
+      )
+    ]
+  ' "${APP_TASK_DEFINITION_FILE}" > "${tmp_dir}/worker-task-definition.json"
+
+TASK_DEFINITION_ARN="$(aws ecs register-task-definition \
+  --cli-input-json "file://${tmp_dir}/worker-task-definition.json" \
+  --region "${AWS_REGION}" \
+  --query 'taskDefinition.taskDefinitionArn' \
+  --output text)"
+
+echo "Registered BYODB migration worker task definition: ${TASK_DEFINITION_ARN}"
+
+aws ecs describe-services \
+  --cluster "${ECS_CLUSTER}" \
+  --services "${WORKER_SERVICE}" \
+  --region "${AWS_REGION}" \
+  --query 'services[0]' > "${tmp_dir}/worker-service.json"
+
+if jq -e '.serviceName != null and .status != "INACTIVE"' "${tmp_dir}/worker-service.json" >/dev/null; then
+  echo "Updating existing BYODB migration worker ECS service: ${WORKER_SERVICE}"
+  aws ecs update-service \
+    --cluster "${ECS_CLUSTER}" \
+    --service "${WORKER_SERVICE}" \
+    --task-definition "${TASK_DEFINITION_ARN}" \
+    --desired-count "${WORKER_DESIRED_COUNT}" \
+    --force-new-deployment \
+    --region "${AWS_REGION}" >/dev/null
+else
+  echo "Creating BYODB migration worker ECS service: ${WORKER_SERVICE}"
+  jq \
+    --arg cluster "${ECS_CLUSTER}" \
+    --arg serviceName "${WORKER_SERVICE}" \
+    --arg taskDefinition "${TASK_DEFINITION_ARN}" \
+    --arg desiredCount "${WORKER_DESIRED_COUNT}" \
+    '
+    {
+      cluster: $cluster,
+      serviceName: $serviceName,
+      taskDefinition: $taskDefinition,
+      desiredCount: ($desiredCount | tonumber),
+      networkConfiguration,
+      platformVersion,
+      enableExecuteCommand,
+      enableECSManagedTags,
+      propagateTags
+    }
+    + if (.capacityProviderStrategy // []) != [] then
+        { capacityProviderStrategy }
+      else
+        { launchType: (.launchType // "FARGATE") }
+      end
+    | with_entries(select(.value != null and .value != []))
+    ' "${tmp_dir}/app-service.json" > "${tmp_dir}/create-worker-service.json"
+
+  aws ecs create-service \
+    --cli-input-json "file://${tmp_dir}/create-worker-service.json" \
+    --region "${AWS_REGION}" >/dev/null
+fi
+
+aws ecs wait services-stable \
+  --cluster "${ECS_CLUSTER}" \
+  --services "${WORKER_SERVICE}" \
+  --region "${AWS_REGION}"
+
+echo "BYODB migration worker ECS service is stable: ${WORKER_SERVICE}"

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -233,6 +233,18 @@ jobs:
           cluster: teable
           wait-for-service-stability: true
 
+      - name: Ensure BYODB migration worker ECS service
+        env:
+          AWS_REGION: us-west-2
+          ECS_CLUSTER: teable
+          APP_SERVICE: teable-service-1
+          APP_CONTAINER: teable
+          APP_TASK_DEFINITION_FILE: task-definition-skip-migrate.json
+          WORKER_TASK_FAMILY: teable-byodb-migration-worker
+          WORKER_SERVICE: teable-byodb-migration-worker
+          WORKER_OTEL_SERVICE_NAME: teable-ai-byodb-migration-worker
+        run: .github/scripts/ensure-byodb-migration-worker-ecs.sh
+
   promote-latest:
     name: Promote Release Tag to Latest
     needs: [prepare, deploy-sandbox, deploy-app]


### PR DESCRIPTION
## Summary
- add the BYODB migration worker to the teable.ai AWS ECS deploy path
- derive the worker task definition from the deployed Teable task definition, using the same teable-cloud image
- create or update a single-replica ECS service named teable-byodb-migration-worker

## Notes
- This does not add a separate worker image.
- The worker command is byodb-migration-worker-skip-migrate, so the main app remains responsible for database migrations.
- teable.cn Sealos already calls ensure-byodb-migration-worker.sh in manual-sealos-deploy.yaml, so this PR leaves that path unchanged.

## Verification
- bash -n .github/scripts/ensure-byodb-migration-worker-ecs.sh
- ruby YAML parse for .github/workflows/manual-ecs-deploy.yml
- git diff --check
- read-only AWS ECS check: teable cluster currently has no teable-byodb-migration-worker service
- dry-run with a fake aws shim verified generated worker task/service JSON without changing AWS
