### PR TITLE
fix(github-actions): fix EE manifest digest artifact match

### DIFF
--- a/.github/workflows/build-teable-ee.yaml
+++ b/.github/workflows/build-teable-ee.yaml
@@ -221,7 +221,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests/${{ matrix.target }}
-          pattern: digests-${{ matrix.target }}-*
+          pattern: digests-${{ matrix.target }}-linux-*
           merge-multiple: true
 
       - name: Create canonical and EE alias manifests


### PR DESCRIPTION
## 背景

`Build teable EE` 在合并 `teable-sandbox` 多架构 manifest 时失败：

```
ghcr.io/teableio/teable-sandbox@sha256:97480a...: not found
```

原因是 `actions/download-artifact` 使用 `digests-sandbox-*`，会同时匹配 `digests-sandbox-linux-*` 和 `digests-sandbox-agent-linux-*`，导致 sandbox manifest 合并阶段误读了 sandbox-agent 的 digest。

## 修改

- 将 digest artifact 下载 pattern 收紧为 `digests-${{ matrix.target }}-linux-*`
- 保持现有 artifact 命名和矩阵结构不变

## 验证

- 本地 glob 模拟确认：
  - `sandbox` 只匹配 `digests-sandbox-linux-amd64/arm64`
  - `sandbox-agent` 只匹配 `digests-sandbox-agent-linux-amd64/arm64`
- `git diff --check -- .github/workflows/build-teable-ee.yaml` 通过
