### PR TITLE
ci(github-actions): 增加 sandbox agent 镜像预热

### DIFF
--- a/.github/workflows/build-teable-cloud.yaml
+++ b/.github/workflows/build-teable-cloud.yaml
@@ -275,8 +275,16 @@ jobs:
       tags: "latest,${{ needs.prepare-release.outputs.source_sha }},${{ needs.prepare-release.outputs.release_id }}"
     secrets: inherit
 
+  preheat-sandbox-agent:
+    needs: [prepare-release, track-start, build-push, sync-ecr, sync-aliyun]
+    if: needs.build-push.result == 'success' && needs.sync-ecr.result == 'success' && needs.sync-aliyun.result == 'success'
+    uses: ./.github/workflows/preheat-sandbox-agent-cloud.yaml
+    with:
+      image_tag: ${{ needs.prepare-release.outputs.release_id }}
+    secrets: inherit
+
   determine-status:
-    needs: [track-start, build-push, sync-ecr, sync-aliyun]
+    needs: [track-start, build-push, sync-ecr, sync-aliyun, preheat-sandbox-agent]
     if: always()
     runs-on: ubuntu-latest
     outputs:
@@ -285,16 +293,16 @@ jobs:
       - name: Determine final status
         id: status
         run: |
-          if [ "${{ needs.build-push.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ] || [ "${{ needs.sync-aliyun.result }}" == "cancelled" ]; then
+          if [ "${{ needs.build-push.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ] || [ "${{ needs.sync-aliyun.result }}" == "cancelled" ] || [ "${{ needs.preheat-sandbox-agent.result }}" == "cancelled" ]; then
             echo "status=Cancelled" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ] && [ "${{ needs.sync-aliyun.result }}" == "success" ]; then
+          elif [ "${{ needs.build-push.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ] && [ "${{ needs.sync-aliyun.result }}" == "success" ] && [ "${{ needs.preheat-sandbox-agent.result }}" == "success" ]; then
             echo "status=Released" >> $GITHUB_OUTPUT
           else
             echo "status=Fail" >> $GITHUB_OUTPUT
           fi
 
   track-complete:
-    needs: [track-start, build-push, sync-ecr, sync-aliyun, determine-status]
+    needs: [track-start, build-push, sync-ecr, sync-aliyun, preheat-sandbox-agent, determine-status]
     if: always()
     uses: ./.github/workflows/track-build-teable.yaml
     with:

--- a/.github/workflows/preheat-sandbox-agent-cloud.yaml
+++ b/.github/workflows/preheat-sandbox-agent-cloud.yaml
@@ -1,0 +1,74 @@
+name: Preheat sandbox agent cloud image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Release image tag (e.g., release.2026-06-11T01-53-35Z.1879)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+    secrets:
+      INFRA_TEABLE_AI_PREHEAT_TOKEN:
+        required: true
+      INFRA_TEABLE_CN_PREHEAT_TOKEN:
+        required: true
+
+jobs:
+  preheat:
+    name: Preheat sandbox agent image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Preheat teable.ai sandbox agent image
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          PREHEAT_TOKEN: ${{ secrets.INFRA_TEABLE_AI_PREHEAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          image="ghcr.io/teableio/teable-sandbox-agent-cloud:${IMAGE_TAG}"
+          payload="$(jq -n --arg image "$image" '{image: $image}')"
+          http_code="$(curl -sS -w "%{http_code}" -o /tmp/preheat-ai-response.json \
+            -X POST 'https://infra.teable.ai/api/image-preheats' \
+            -H "Authorization: Bearer ${PREHEAT_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            --data "$payload")"
+
+          response="$(cat /tmp/preheat-ai-response.json)"
+          echo "Preheat image: ${image}"
+          echo "HTTP status: ${http_code}"
+          echo "Response: ${response}"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::teable.ai image preheat failed with HTTP ${http_code}"
+            exit 1
+          fi
+
+      - name: Preheat teable.cn sandbox agent image
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          PREHEAT_TOKEN: ${{ secrets.INFRA_TEABLE_CN_PREHEAT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          image="registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-cloud:${IMAGE_TAG}"
+          payload="$(jq -n --arg image "$image" '{image: $image}')"
+          http_code="$(curl -sS -w "%{http_code}" -o /tmp/preheat-cn-response.json \
+            -X POST 'https://infra.teable.cn/api/image-preheats' \
+            -H "Authorization: Bearer ${PREHEAT_TOKEN}" \
+            -H 'Content-Type: application/json' \
+            --data "$payload")"
+
+          response="$(cat /tmp/preheat-cn-response.json)"
+          echo "Preheat image: ${image}"
+          echo "HTTP status: ${http_code}"
+          echo "Response: ${response}"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::teable.cn image preheat failed with HTTP ${http_code}"
+            exit 1
+          fi


### PR DESCRIPTION
## 变更
- 新增 sandbox agent cloud 镜像预热 reusable workflow
- cloud 构建在 ECR 与 Aliyun 同步成功后，用 release tag 触发 teable.ai 与 teable.cn 镜像预热
- 将预热结果纳入 Released/Fail 状态判断，避免预热失败但发布记录显示成功

## 说明
- 镜像引用统一使用 `release.*` tag，例如 `release.2026-06-11T01-53-35Z.1879`
- 预热 token 使用 GitHub Actions secrets：`INFRA_TEABLE_AI_PREHEAT_TOKEN`、`INFRA_TEABLE_CN_PREHEAT_TOKEN`，不写入仓库

## 验证
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/build-teable-cloud.yaml .github/workflows/preheat-sandbox-agent-cloud.yaml`\n- `actionlint .github/workflows/build-teable-cloud.yaml .github/workflows/preheat-sandbox-agent-cloud.yaml`\n- `git diff --check`