### PR TITLE
ci: notify teable-infra after promoting teable:latest

### DIFF
--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -68,3 +68,21 @@ jobs:
       edition: ee
       tags: "latest"
     secrets: inherit
+
+  notify-infra:
+    name: Notify teable-infra platform release
+    needs: [promote-latest, sync-aliyun]
+    if: needs.promote-latest.result == 'success' && needs.sync-aliyun.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch teable-stable-promoted to teable-infra
+        env:
+          DISPATCH_TOKEN: ${{ secrets.TEABLE_INFRA_DISPATCH_TOKEN }}
+          RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/teableio/teable-infra/dispatches \
+            -d "{\"event_type\":\"teable-stable-promoted\",\"client_payload\":{\"release_id\":\"${RELEASE_ID}\"}}"
+          echo "dispatched teable-stable-promoted release_id=${RELEASE_ID}"


### PR DESCRIPTION
## What

After `promote-latest` + `sync-aliyun` succeed, send `repository_dispatch` (`teable-stable-promoted`, `client_payload.release_id`) to `teableio/teable-infra`.

## Why

The public deployment repo pins `ghcr.io/teableio/teable` by resolving `latest` at platform-release generation time. When `latest` moves but nothing changes on the infra side, the public pin goes stale. The receiver workflow in teable-infra (merged, teableio/teable-infra#55) adds a CHANGELOG entry and opens a PR; when no other pending changes exist it auto-merges, cutting a platform release so `versions.yaml` follows the stable channel automatically. With pending changes it waits for manual merge.

## Setup already done

- `TEABLE_INFRA_DISPATCH_TOKEN` secret is configured in this repo.
- Receiver workflow + `CROSS_REPO_PAT` are live in teable-infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)