### PR TITLE
ci: skip agent latest tag in ee Aliyun sync

### DIFF
--- a/.github/workflows/sync-aliyun.yaml
+++ b/.github/workflows/sync-aliyun.yaml
@@ -119,8 +119,12 @@ jobs:
 
             # Single canonical sandbox agent (no -ee/-cloud alias); both
             # teable.ai and teable.cn preheat teable/teable-sandbox-agent.
+            # "latest" is skipped: the agent publishes no latest tag (its only
+            # consumers pull prefix + explicit app build tag). Same rule as the
+            # cloud lane above; without it every ee latest-promotion sync fails.
             for tag in "${TAGS[@]}"; do
               [ -n "$tag" ] || continue
+              [ "$tag" = "latest" ] && continue
               retry_copy \
                 "${SRC_REGISTRY}/teable-sandbox-agent:${tag}" \
                 "${DST_REGISTRY}/teable-sandbox-agent:${tag}" \


### PR DESCRIPTION
## Why

The last three `promote-latest-ee` runs all failed in `sync-aliyun / Sync ee images`: the ee lane tries to sync `teable-sandbox-agent:latest`, but the agent publishes **no latest tag by design** (consumers pull prefix + explicit app build tag), so it fails after 5 retries every time. The image promotions themselves succeed — only the sync job goes red, and it also blocks the `notify-infra` dispatch added in #51 (which requires sync success).

## What

Mirror the exact skip (and comment) the **cloud lane already has** into the ee lane: `[ "$tag" = "latest" ] && continue` before the agent copy.

After merging, re-dispatching `promote-latest-ee` for the current release will complete green and fire the teable-infra notification end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)