### PR TITLE
ci: split staging/production channels — merges stay on ghcr+ECR, durable tags stamp at launch

### DIFF
--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -11,8 +11,16 @@ name: Build teable (unified)
 # syncs simply `needs: merge-agent-manifest` in-run.
 #
 # mode=rehearsal (validation runs): builds everything and pushes ONLY the
-# release-id tag to ghcr — no beta/latest/sha movement, no dockerhub/aliyun/
-# ECR sync, no preheat, no tracking records.
+# release-id tag to ghcr — no beta/latest movement, no dockerhub/ECR sync,
+# no tracking records.
+#
+# Channel split: a routine develop merge is a STAGING build — it pushes the
+# pinned release-id to ghcr (+ ECR for the AWS staging cluster) and moves the
+# floating beta, nothing more. The durable/public tags and the Aliyun mirror
+# are produced at release time instead: manual-ecs-deploy (cloud production)
+# and promote-latest-ee (EE stable) stamp prod-<release-id> markers, move
+# latest, and run the dockerhub/aliyun syncs + agent preheat. ghcr-gc.yaml
+# reaps unpromoted staging versions after their rolling window.
 
 concurrency:
   group: build-teable-unified-${{ github.ref }}
@@ -126,17 +134,18 @@ jobs:
           fi
 
           MODE="${INPUT_MODE:-release}"
-          if [ "$MODE" = "rehearsal" ]; then
+          # Staging-channel tagging: pinned release-id only. No sha tags
+          # (the release record maps release-id -> commit), and the cloud
+          # latest tag is NOT moved here — latest means "current production"
+          # and only manual-ecs-deploy moves it after a successful deploy.
+          # The EE beta channel keeps floating with develop.
+          if [ "$MODE" = "rehearsal" ] || [ "$SOURCE_REF" != "develop" ]; then
+            # Rehearsals and branch/ref builds never move floating tags.
             EE_TAGS="$RELEASE_ID"
             CLOUD_TAGS="$RELEASE_ID"
-          elif [ "$SOURCE_REF" != "develop" ]; then
-            # Branch/ref releases get pinned tags only — the floating beta and
-            # latest tags may only ever move to develop builds.
-            EE_TAGS="${SOURCE_SHA},${RELEASE_ID}"
-            CLOUD_TAGS="${SOURCE_SHA},${RELEASE_ID}"
           else
-            EE_TAGS="beta,${SOURCE_SHA},${RELEASE_ID}"
-            CLOUD_TAGS="latest,${SOURCE_SHA},${RELEASE_ID}"
+            EE_TAGS="beta,${RELEASE_ID}"
+            CLOUD_TAGS="${RELEASE_ID}"
           fi
 
           {
@@ -500,7 +509,8 @@ jobs:
   # Deliberately NOT gated on ensure-agent-base: the cloud images don't
   # consume the agent base, and in the old two-workflow world a base failure
   # never stopped the cloud images from being built and pushed (only the
-  # Released status). merge-agent-manifest still gates the cloud syncs.
+  # Released status). merge-agent-manifest still gates the cloud Released
+  # status — staging sandboxes pull the agent release tag from ghcr.
   build-push-cloud:
     needs: [prepare-release]
     runs-on: ${{ matrix.runner }}
@@ -694,9 +704,14 @@ jobs:
 
   # ── EE distribution chain ──────────────────────────────────────────────
 
+  # Per-merge Docker Hub sync is the beta channel only. The pinned release
+  # tags, the Aliyun mirror, and the agent preheat all moved to release time
+  # (manual-ecs-deploy for cloud, promote-latest-ee for EE) — a staging build
+  # publishes nothing durable. Skipped entirely on non-develop builds, which
+  # carry no beta tag.
   sync-dockerhub:
     needs: [prepare-release, merge-manifests-ee, merge-agent-manifest]
-    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-manifests-ee.result == 'success' && needs.merge-agent-manifest.result == 'success'
+    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-manifests-ee.result == 'success' && needs.merge-agent-manifest.result == 'success' && contains(needs.prepare-release.outputs.ee_tags, 'beta')
     runs-on: ubuntu-latest
     steps:
       - name: Install skopeo
@@ -704,7 +719,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
 
-      - name: Sync images to Docker Hub
+      - name: Sync beta channel to Docker Hub
         env:
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
           DST_CREDS: ${{ vars.DOCKER_HUB_NAME }}:${{ secrets.DOCKER_HUB_AK }}
@@ -712,36 +727,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          IFS=',' read -ra TAG_LIST <<< "$TAGS"
-          IMAGES=("teable" "teable-ee" "teable-sandbox" "teable-sandbox-ee" "teable-sandbox-agent")
-
-          for image in "${IMAGES[@]}"; do
-            for tag in "${TAG_LIST[@]}"; do
-              [ -n "$tag" ] || continue
-              skopeo copy --all \
-                --src-creds="$SRC_CREDS" \
-                --dest-creds="$DST_CREDS" \
-                "docker://${{ env.REGISTRY_GITHUB }}/${image}:${tag}" \
-                "docker://${{ env.REGISTRY_DOCKERHUB }}/${image}:${tag}"
-            done
+          for image in teable teable-ee teable-sandbox teable-sandbox-ee; do
+            skopeo copy --all \
+              --src-creds="$SRC_CREDS" \
+              --dest-creds="$DST_CREDS" \
+              "docker://${{ env.REGISTRY_GITHUB }}/${image}:beta" \
+              "docker://${{ env.REGISTRY_DOCKERHUB }}/${image}:beta"
           done
 
-  sync-aliyun-ee:
-    needs: [prepare-release, merge-manifests-ee, merge-agent-manifest]
-    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-manifests-ee.result == 'success' && needs.merge-agent-manifest.result == 'success'
-    uses: ./.github/workflows/sync-aliyun.yaml
-    with:
-      edition: ee
-      tags: ${{ needs.prepare-release.outputs.ee_tags }}
-    secrets: inherit
-
-  preheat-sandbox-agent:
-    needs: [prepare-release, merge-agent-manifest, sync-aliyun-ee]
-    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-agent-manifest.result == 'success' && needs.sync-aliyun-ee.result == 'success'
-    uses: ./.github/workflows/preheat-sandbox-agent-cloud.yaml
-    with:
-      image_tag: ${{ needs.prepare-release.outputs.release_id }}
-    secrets: inherit
+          # The agent is the one image whose PINNED tags must still ship per
+          # merge: a running app resolves its agent image as
+          # <prefix>:<the app's own build release-id> at sandbox spawn, so a
+          # beta user pulled today needs today's agent release-id available
+          # for as long as they run that app build. (Same reason the
+          # teable-sandbox-agent package is exempt from ghcr GC.)
+          IFS=',' read -ra TAG_LIST <<< "$TAGS"
+          for tag in "${TAG_LIST[@]}"; do
+            [ -n "$tag" ] || continue
+            [ "$tag" = "beta" ] && continue
+            skopeo copy --all \
+              --src-creds="$SRC_CREDS" \
+              --dest-creds="$DST_CREDS" \
+              "docker://${{ env.REGISTRY_GITHUB }}/teable-sandbox-agent:${tag}" \
+              "docker://${{ env.REGISTRY_DOCKERHUB }}/teable-sandbox-agent:${tag}"
+          done
 
   # ── Cloud distribution chain ───────────────────────────────────────────
 
@@ -785,18 +794,6 @@ jobs:
             done
           done
 
-  # The cloud Aliyun sync also copies the canonical agent tag; depending on
-  # merge-agent-manifest directly (same run) replaces the old cross-workflow
-  # verify-agent poll.
-  sync-aliyun-cloud:
-    needs: [prepare-release, build-push-cloud, merge-agent-manifest]
-    if: needs.prepare-release.outputs.mode == 'release' && needs.build-push-cloud.result == 'success' && needs.merge-agent-manifest.result == 'success'
-    uses: ./.github/workflows/sync-aliyun.yaml
-    with:
-      edition: cloud
-      tags: ${{ needs.prepare-release.outputs.cloud_tags }}
-    secrets: inherit
-
   # ── Per-edition statuses (independent releases from one run) ───────────
 
   determine-status-ee:
@@ -807,8 +804,6 @@ jobs:
         merge-manifests-ee,
         merge-agent-manifest,
         sync-dockerhub,
-        sync-aliyun-ee,
-        preheat-sandbox-agent,
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -818,11 +813,14 @@ jobs:
       - name: Determine final EE status
         id: status
         run: |
+          # sync-dockerhub legitimately skips on non-develop builds (no beta
+          # tag to sync), so "skipped" counts as success for it.
+          DOCKERHUB="${{ needs.sync-dockerhub.result }}"
           if [ "${{ needs.prepare-release.outputs.mode }}" != "release" ]; then
             echo "status=Rehearsal" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-dockerhub.result }}" == "cancelled" ] || [ "${{ needs.sync-aliyun-ee.result }}" == "cancelled" ] || [ "${{ needs.preheat-sandbox-agent.result }}" == "cancelled" ]; then
+          elif [ "${{ needs.build-push-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "$DOCKERHUB" == "cancelled" ]; then
             echo "status=Cancelled" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-ee.result }}" == "success" ] && [ "${{ needs.merge-manifests-ee.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-dockerhub.result }}" == "success" ] && [ "${{ needs.sync-aliyun-ee.result }}" == "success" ] && [ "${{ needs.preheat-sandbox-agent.result }}" == "success" ]; then
+          elif [ "${{ needs.build-push-ee.result }}" == "success" ] && [ "${{ needs.merge-manifests-ee.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && { [ "$DOCKERHUB" == "success" ] || [ "$DOCKERHUB" == "skipped" ]; }; then
             echo "status=Released" >> $GITHUB_OUTPUT
           else
             echo "status=Fail" >> $GITHUB_OUTPUT
@@ -835,7 +833,6 @@ jobs:
         build-push-cloud,
         merge-agent-manifest,
         sync-ecr,
-        sync-aliyun-cloud,
       ]
     if: always()
     runs-on: ubuntu-latest
@@ -847,9 +844,9 @@ jobs:
         run: |
           if [ "${{ needs.prepare-release.outputs.mode }}" != "release" ]; then
             echo "status=Rehearsal" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-cloud.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ] || [ "${{ needs.sync-aliyun-cloud.result }}" == "cancelled" ]; then
+          elif [ "${{ needs.build-push-cloud.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ]; then
             echo "status=Cancelled" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-cloud.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ] && [ "${{ needs.sync-aliyun-cloud.result }}" == "success" ]; then
+          elif [ "${{ needs.build-push-cloud.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ]; then
             echo "status=Released" >> $GITHUB_OUTPUT
           else
             echo "status=Fail" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -39,7 +39,6 @@ concurrency:
 env:
   REGISTRY_GITHUB: ghcr.io/teableio
   REGISTRY_DOCKERHUB: docker.io/teableio
-  EE_IMAGE_SUFFIX: "-ee"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -11,16 +11,26 @@ name: Build teable (unified)
 # syncs simply `needs: merge-agent-manifest` in-run.
 #
 # mode=rehearsal (validation runs): builds everything and pushes ONLY the
-# release-id tag to ghcr — no beta/latest movement, no dockerhub/ECR sync,
-# no tracking records.
+# pinned beta-* tag — no beta/latest movement, no dockerhub/ECR sync, no
+# tracking records.
 #
-# Channel split: a routine develop merge is a STAGING build — it pushes the
-# pinned release-id to ghcr (+ ECR for the AWS staging cluster) and moves the
-# floating beta, nothing more. The durable/public tags and the Aliyun mirror
-# are produced at release time instead: manual-ecs-deploy (cloud production)
-# and promote-latest-ee (EE stable) stamp prod-<release-id> markers, move
-# latest, and run the dockerhub/aliyun syncs + agent preheat. ghcr-gc.yaml
-# reaps unpromoted staging versions after their rolling window.
+# Channel split — "a release.* tag means an official release":
+#   - Every build keeps release.<ts>.<seq> as its IDENTITY (BUILD_VERSION
+#     baked into the image, Sentry release, tracking records, and the tag
+#     the running app uses to pull its sandbox agent). That string never
+#     changes meaning.
+#   - The REGISTRY tag of a staging build is the derived beta-<ts>.<seq>
+#     (prefix swap, bijective). Deploy workflows map between the two.
+#   - Only launch workflows stamp release.<id>: manual-ecs-deploy for cloud
+#     (ghcr+ECR+Aliyun), promote-latest-ee for EE (ghcr+dockerhub+Aliyun).
+#     They then reap old beta-* versions; ghcr-gc.yaml backstops.
+#   - The PUBLIC packages (teable, teable-ee) never see staging tags at
+#     all: EE app staging builds live in the INTERNAL twin package
+#     teable-staging, and only promotion copies them out. The floating
+#     public beta channel still tracks develop (stamped cross-repo).
+#   - The agent is the one exception: it is tagged release.<id> on every
+#     build, because every app build (staging or production) pulls
+#     <prefix>:<its own BUILD_VERSION> at sandbox spawn.
 
 concurrency:
   group: build-teable-unified-${{ github.ref }}
@@ -68,8 +78,8 @@ jobs:
       source_sha: ${{ steps.source.outputs.source_sha }}
       agent_base_tag: ${{ steps.agent_base.outputs.tag }}
       mode: ${{ steps.release.outputs.mode }}
-      ee_tags: ${{ steps.release.outputs.ee_tags }}
-      cloud_tags: ${{ steps.release.outputs.cloud_tags }}
+      beta_tag: ${{ steps.release.outputs.beta_tag }}
+      float_beta: ${{ steps.release.outputs.float_beta }}
     steps:
       - name: Checkout private repository
         uses: actions/checkout@v4
@@ -105,8 +115,12 @@ jobs:
           SOURCE_REF: ${{ github.event.client_payload.source_ref || inputs.source_ref || 'develop' }}
           SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
         run: |
-          EE_TARGET_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox"}]}'
-          EE_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"app","file":"Dockerfile","image":"teable","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"}]}'
+          # EE app staging pushes land in the INTERNAL teable-staging twin so
+          # the public teable/teable-ee tag lists only show official releases.
+          # The sandbox packages are internal-visibility, so they stage in
+          # place. release_image/alias_image are where promotion publishes.
+          EE_TARGET_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-staging","release_image":"teable","alias_image":"teable-ee"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","release_image":"teable-sandbox","alias_image":"teable-sandbox-ee"}]}'
+          EE_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-staging","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"app","file":"Dockerfile","image":"teable-staging","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"}]}'
           CLOUD_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-cloud","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox-cloud","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"}]}'
 
           if [ -n "$INPUT_RELEASE_ID" ]; then
@@ -134,18 +148,19 @@ jobs:
           fi
 
           MODE="${INPUT_MODE:-release}"
-          # Staging-channel tagging: pinned release-id only. No sha tags
-          # (the release record maps release-id -> commit), and the cloud
-          # latest tag is NOT moved here — latest means "current production"
-          # and only manual-ecs-deploy moves it after a successful deploy.
-          # The EE beta channel keeps floating with develop.
+          # Staging registry tag: bijective prefix swap of the release id.
+          # release.<ts>.<seq>  <->  beta-<ts>.<seq>
+          # The release.* tag is only ever stamped by a launch workflow.
+          # No sha tags (the release record maps release-id -> commit), and
+          # the cloud latest tag is NOT moved here — latest means "current
+          # production" and only manual-ecs-deploy moves it after a
+          # successful deploy. The public EE beta channel keeps floating
+          # with develop; rehearsals and branch/ref builds never move it.
+          BETA_TAG="beta-${RELEASE_ID#release.}"
           if [ "$MODE" = "rehearsal" ] || [ "$SOURCE_REF" != "develop" ]; then
-            # Rehearsals and branch/ref builds never move floating tags.
-            EE_TAGS="$RELEASE_ID"
-            CLOUD_TAGS="$RELEASE_ID"
+            FLOAT_BETA="false"
           else
-            EE_TAGS="beta,${RELEASE_ID}"
-            CLOUD_TAGS="${RELEASE_ID}"
+            FLOAT_BETA="true"
           fi
 
           {
@@ -156,8 +171,8 @@ jobs:
             echo "release_timestamp=$RELEASE_TIMESTAMP"
             echo "release_sequence=$RELEASE_SEQUENCE"
             echo "mode=$MODE"
-            echo "ee_tags=$EE_TAGS"
-            echo "cloud_tags=$CLOUD_TAGS"
+            echo "beta_tag=$BETA_TAG"
+            echo "float_beta=$FLOAT_BETA"
           } >> "$GITHUB_OUTPUT"
           echo "Release id: $RELEASE_ID (mode=$MODE)"
 
@@ -386,10 +401,14 @@ jobs:
           pattern: digests-sandbox-agent-linux-*
           merge-multiple: true
 
+      # The agent is tagged with the RELEASE id on every build — runtime
+      # contract: every app build (staging or production) pulls
+      # <prefix>:<its own BUILD_VERSION>, and BUILD_VERSION is always the
+      # release id. This package is exempt from all beta cleanup.
       - name: Create canonical manifests
         env:
           CANONICAL_IMAGE: ${{ env.REGISTRY_GITHUB }}/teable-sandbox-agent
-          TAGS: ${{ needs.prepare-release.outputs.ee_tags }}
+          TAGS: ${{ needs.prepare-release.outputs.release_id }}
         run: |
           mapfile -t DIGEST_FILES < <(find /tmp/digests/sandbox-agent -type f -name '*.digest' | sort)
           if [ "${#DIGEST_FILES[@]}" -eq 0 ]; then
@@ -538,18 +557,8 @@ jobs:
 
       - name: Compose image tags
         id: tags
-        env:
-          TAGS: ${{ needs.prepare-release.outputs.cloud_tags }}
         run: |
-          {
-            echo 'list<<TAGS_EOF'
-            IFS=',' read -ra TAG_LIST <<< "$TAGS"
-            for tag in "${TAG_LIST[@]}"; do
-              [ -n "$tag" ] || continue
-              echo "${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}:${tag}"
-            done
-            echo 'TAGS_EOF'
-          } >> "$GITHUB_OUTPUT"
+          echo "list=${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}:${{ needs.prepare-release.outputs.beta_tag }}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare generated Docker contexts
         if: matrix.file == 'Dockerfile'
@@ -672,11 +681,13 @@ jobs:
           pattern: digests-${{ matrix.target }}-linux-*
           merge-multiple: true
 
-      - name: Create canonical and EE alias manifests
+      - name: Create staging manifests and float the beta channel
         env:
-          CANONICAL_IMAGE: ${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}
-          EE_ALIAS_IMAGE: ${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}${{ env.EE_IMAGE_SUFFIX }}
-          TAGS: ${{ needs.prepare-release.outputs.ee_tags }}
+          STAGING_IMAGE: ${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}
+          RELEASE_IMAGE: ${{ env.REGISTRY_GITHUB }}/${{ matrix.release_image }}
+          ALIAS_IMAGE: ${{ env.REGISTRY_GITHUB }}/${{ matrix.alias_image }}
+          BETA_TAG: ${{ needs.prepare-release.outputs.beta_tag }}
+          FLOAT_BETA: ${{ needs.prepare-release.outputs.float_beta }}
         run: |
           mapfile -t DIGEST_FILES < <(find "/tmp/digests/${{ matrix.target }}" -type f -name '*.digest' | sort)
 
@@ -688,19 +699,34 @@ jobs:
           SOURCES=()
           for digest_file in "${DIGEST_FILES[@]}"; do
             digest="$(tr -d '\n' < "$digest_file")"
-            SOURCES+=("${CANONICAL_IMAGE}@${digest}")
+            SOURCES+=("${STAGING_IMAGE}@${digest}")
           done
 
-          IFS=',' read -ra TAG_LIST <<< "$TAGS"
-          for tag in "${TAG_LIST[@]}"; do
-            [ -n "$tag" ] || continue
+          # Pinned staging tag on the staging package (the app's INTERNAL
+          # teable-staging twin, or the sandbox package in place).
+          docker buildx imagetools create \
+            --tag "${STAGING_IMAGE}:${BETA_TAG}" \
+            "${SOURCES[@]}"
+
+          # When staging in place (sandbox), keep the pinned -ee alias too.
+          # The app twin gets no public pinned tag — promotion publishes it.
+          if [ "${STAGING_IMAGE}" = "${RELEASE_IMAGE}" ]; then
             docker buildx imagetools create \
-              --tag "${CANONICAL_IMAGE}:${tag}" \
-              "${SOURCES[@]}"
+              --tag "${ALIAS_IMAGE}:${BETA_TAG}" \
+              "${STAGING_IMAGE}:${BETA_TAG}"
+          fi
+
+          # The public beta CHANNEL keeps tracking develop — only the
+          # floating pointer moves; no pinned staging tag ever lands on the
+          # public packages.
+          if [ "${FLOAT_BETA}" = "true" ]; then
             docker buildx imagetools create \
-              --tag "${EE_ALIAS_IMAGE}:${tag}" \
-              "${CANONICAL_IMAGE}:${tag}"
-          done
+              --tag "${RELEASE_IMAGE}:beta" \
+              "${STAGING_IMAGE}:${BETA_TAG}"
+            docker buildx imagetools create \
+              --tag "${ALIAS_IMAGE}:beta" \
+              "${RELEASE_IMAGE}:beta"
+          fi
 
   # ── EE distribution chain ──────────────────────────────────────────────
 
@@ -708,10 +734,10 @@ jobs:
   # tags, the Aliyun mirror, and the agent preheat all moved to release time
   # (manual-ecs-deploy for cloud, promote-latest-ee for EE) — a staging build
   # publishes nothing durable. Skipped entirely on non-develop builds, which
-  # carry no beta tag.
+  # never move the beta channel.
   sync-dockerhub:
     needs: [prepare-release, merge-manifests-ee, merge-agent-manifest]
-    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-manifests-ee.result == 'success' && needs.merge-agent-manifest.result == 'success' && contains(needs.prepare-release.outputs.ee_tags, 'beta')
+    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-manifests-ee.result == 'success' && needs.merge-agent-manifest.result == 'success' && needs.prepare-release.outputs.float_beta == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Install skopeo
@@ -723,7 +749,7 @@ jobs:
         env:
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
           DST_CREDS: ${{ vars.DOCKER_HUB_NAME }}:${{ secrets.DOCKER_HUB_AK }}
-          TAGS: ${{ needs.prepare-release.outputs.ee_tags }}
+          RELEASE_ID: ${{ needs.prepare-release.outputs.release_id }}
         run: |
           set -euo pipefail
 
@@ -735,22 +761,17 @@ jobs:
               "docker://${{ env.REGISTRY_DOCKERHUB }}/${image}:beta"
           done
 
-          # The agent is the one image whose PINNED tags must still ship per
-          # merge: a running app resolves its agent image as
-          # <prefix>:<the app's own build release-id> at sandbox spawn, so a
-          # beta user pulled today needs today's agent release-id available
+          # The agent is the one image whose PINNED release tag must still
+          # ship per merge: a running app resolves its agent image as
+          # <prefix>:<its own BUILD_VERSION (release id)> at sandbox spawn,
+          # so a beta user who pulled today needs today's agent release tag
           # for as long as they run that app build. (Same reason the
-          # teable-sandbox-agent package is exempt from ghcr GC.)
-          IFS=',' read -ra TAG_LIST <<< "$TAGS"
-          for tag in "${TAG_LIST[@]}"; do
-            [ -n "$tag" ] || continue
-            [ "$tag" = "beta" ] && continue
-            skopeo copy --all \
-              --src-creds="$SRC_CREDS" \
-              --dest-creds="$DST_CREDS" \
-              "docker://${{ env.REGISTRY_GITHUB }}/teable-sandbox-agent:${tag}" \
-              "docker://${{ env.REGISTRY_DOCKERHUB }}/teable-sandbox-agent:${tag}"
-          done
+          # teable-sandbox-agent package is exempt from beta cleanup.)
+          skopeo copy --all \
+            --src-creds="$SRC_CREDS" \
+            --dest-creds="$DST_CREDS" \
+            "docker://${{ env.REGISTRY_GITHUB }}/teable-sandbox-agent:${RELEASE_ID}" \
+            "docker://${{ env.REGISTRY_DOCKERHUB }}/teable-sandbox-agent:${RELEASE_ID}"
 
   # ── Cloud distribution chain ───────────────────────────────────────────
 
@@ -774,24 +795,20 @@ jobs:
       - name: Sync images to ECR
         env:
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
-          TAGS: ${{ needs.prepare-release.outputs.cloud_tags }}
+          BETA_TAG: ${{ needs.prepare-release.outputs.beta_tag }}
           ECR_REGISTRY: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable
         run: |
           set -euo pipefail
 
           ECR_PASSWORD="$(aws ecr get-login-password --region us-west-2)"
-          IFS=',' read -ra TAG_LIST <<< "$TAGS"
           IMAGES=("teable-cloud" "teable-sandbox-cloud")
 
           for image in "${IMAGES[@]}"; do
-            for tag in "${TAG_LIST[@]}"; do
-              [ -n "$tag" ] || continue
-              skopeo copy --all \
-                --src-creds="$SRC_CREDS" \
-                --dest-creds="AWS:${ECR_PASSWORD}" \
-                "docker://${{ env.REGISTRY_GITHUB }}/${image}:${tag}" \
-                "docker://${ECR_REGISTRY}/${image}:${tag}"
-            done
+            skopeo copy --all \
+              --src-creds="$SRC_CREDS" \
+              --dest-creds="AWS:${ECR_PASSWORD}" \
+              "docker://${{ env.REGISTRY_GITHUB }}/${image}:${BETA_TAG}" \
+              "docker://${ECR_REGISTRY}/${image}:${BETA_TAG}"
           done
 
   # ── Per-edition statuses (independent releases from one run) ───────────
@@ -813,8 +830,8 @@ jobs:
       - name: Determine final EE status
         id: status
         run: |
-          # sync-dockerhub legitimately skips on non-develop builds (no beta
-          # tag to sync), so "skipped" counts as success for it.
+          # sync-dockerhub legitimately skips on non-develop builds (the
+          # beta channel doesn't move), so "skipped" counts as success.
           DOCKERHUB="${{ needs.sync-dockerhub.result }}"
           if [ "${{ needs.prepare-release.outputs.mode }}" != "release" ]; then
             echo "status=Rehearsal" >> $GITHUB_OUTPUT

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -82,15 +82,15 @@ jobs:
         id: start_time
         run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
 
-  # Production deploys run from the durable prod-<release-id> tag, stamped
-  # here BEFORE anything is deployed. Staging builds only carry their pinned
-  # release-id, which ghcr-gc.yaml / the ECR lifecycle policy reap after a
-  # rolling window — the prod-* stamp is what makes a deployed version (and
-  # every task-definition revision referencing it, i.e. rollback targets)
-  # permanently pullable. Stamping also keeps the co-located release-id tag
-  # alive on ghcr, which running apps use to pull their sandbox agent.
-  stamp-prod:
-    name: Stamp prod release tags
+  # Production deploys run from the official release.<id> tag. A staging
+  # build only carries its beta-<id> registry twin, so the FIRST launch of a
+  # build stamps release.<id> from it (ghcr + ECR) before anything deploys —
+  # the presence of a release.* tag is what makes a version official,
+  # permanently retained, and exempt from beta cleanup / the ECR lifecycle
+  # policy. Re-deploys of an already-released id (rollbacks) find the tag
+  # present and skip, so they work even after the beta twin is reaped.
+  stamp-release:
+    name: Stamp official release tags
     needs: prepare
     runs-on: ubuntu-latest
 
@@ -115,26 +115,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Stamp prod tags
+      - name: Stamp release tags from the staging build
         env:
           RELEASE_ID: ${{ inputs.image_tag }}
           ECR_REGISTRY: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable
         run: |
           set -euo pipefail
+          BETA_TAG="beta-${RELEASE_ID#release.}"
           REGISTRIES=("ghcr.io/teableio" "$ECR_REGISTRY")
           IMAGES=("teable-cloud" "teable-sandbox-cloud")
 
           for REGISTRY in "${REGISTRIES[@]}"; do
             for IMAGE in "${IMAGES[@]}"; do
+              if docker buildx imagetools inspect "$REGISTRY/${IMAGE}:${RELEASE_ID}" >/dev/null 2>&1; then
+                echo "✅ ${IMAGE}:${RELEASE_ID} already stamped on ${REGISTRY}"
+                continue
+              fi
               docker buildx imagetools create \
-                --tag "$REGISTRY/${IMAGE}:prod-${RELEASE_ID}" \
-                "$REGISTRY/${IMAGE}:${RELEASE_ID}"
+                --tag "$REGISTRY/${IMAGE}:${RELEASE_ID}" \
+                "$REGISTRY/${IMAGE}:${BETA_TAG}"
             done
           done
 
   deploy-sandbox:
     name: Deploy Sandbox to ECS
-    needs: [prepare, stamp-prod]
+    needs: [prepare, stamp-release]
     runs-on: ubuntu-latest
 
     steps:
@@ -165,7 +170,7 @@ jobs:
         with:
           task-definition: sandbox-task-definition.json
           container-name: teable-sandbox
-          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-sandbox-cloud:prod-${{ inputs.image_tag }}
+          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-sandbox-cloud:${{ inputs.image_tag }}
 
       - name: Deploy sandbox to ECS service
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
@@ -235,7 +240,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: teable
-          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud:prod-${{ inputs.image_tag }}
+          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud:${{ inputs.image_tag }}
 
       - name: Run database migration as one-off task
         run: |
@@ -368,12 +373,12 @@ jobs:
             done
           done
 
-# Aliyun receives images ONLY at release time. The pinned release-id must
-  # ship alongside latest: teable.cn (manual-sealos-deploy) deploys that
-  # pinned tag from Aliyun, and the sync's cloud lane also carries the
+  # Aliyun receives images ONLY at release time. The official release.<id>
+  # must ship alongside latest: teable.cn (manual-sealos-deploy) deploys
+  # that pinned tag from Aliyun, and the sync's cloud lane also carries the
   # canonical agent tag that CN sandboxes pull.
   sync-aliyun:
-    needs: promote-latest
+    needs: [stamp-release, promote-latest]
     if: needs.promote-latest.result == 'success'
     uses: ./.github/workflows/sync-aliyun.yaml
     with:
@@ -391,6 +396,33 @@ jobs:
     with:
       image_tag: ${{ inputs.image_tag }}
     secrets: inherit
+
+  # With the release stamped and deployed, the accumulated cloud staging
+  # versions have served their purpose: reap beta-* keeping a small cushion
+  # for staging rollback. The launched version itself only loses its beta-
+  # tag — the image survives, now carrying release.<id>. Without the
+  # GHCR_GC_TOKEN delete:packages PAT this runs as a dry-run. Shares the
+  # ghcr-gc concurrency group: the cleanup action must never run twice
+  # against the same package.
+  cleanup-beta:
+    name: Reap cloud staging versions
+    needs: [deploy-sandbox, deploy-app, promote-latest]
+    if: needs.deploy-sandbox.result == 'success' && needs.deploy-app.result == 'success'
+    concurrency:
+      group: ghcr-gc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old beta versions of the cloud packages
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        with:
+          token: ${{ secrets.GHCR_GC_TOKEN || secrets.PACKAGES_KEY }}
+          owner: teableio
+          packages: teable-cloud,teable-sandbox-cloud
+          delete-tags: beta-*
+          keep-n-tagged: 5
+          exclude-tags: latest,release.*
+          validate: true
+          dry-run: ${{ secrets.GHCR_GC_TOKEN == '' }}
 
   notify:
     name: Record Deployment in Teable

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -64,6 +64,10 @@ on:
         required: true
       TEABLE_API_TOKEN:
         required: false
+      INFRA_TEABLE_AI_PREHEAT_TOKEN:
+        required: false
+      INFRA_TEABLE_CN_PREHEAT_TOKEN:
+        required: false
 
 jobs:
   prepare:
@@ -78,9 +82,59 @@ jobs:
         id: start_time
         run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
 
+  # Production deploys run from the durable prod-<release-id> tag, stamped
+  # here BEFORE anything is deployed. Staging builds only carry their pinned
+  # release-id, which ghcr-gc.yaml / the ECR lifecycle policy reap after a
+  # rolling window — the prod-* stamp is what makes a deployed version (and
+  # every task-definition revision referencing it, i.e. rollback targets)
+  # permanently pullable. Stamping also keeps the co-located release-id tag
+  # alive on ghcr, which running apps use to pull their sandbox agent.
+  stamp-prod:
+    name: Stamp prod release tags
+    needs: prepare
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PACKAGES_KEY }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to AWS ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Stamp prod tags
+        env:
+          RELEASE_ID: ${{ inputs.image_tag }}
+          ECR_REGISTRY: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable
+        run: |
+          set -euo pipefail
+          REGISTRIES=("ghcr.io/teableio" "$ECR_REGISTRY")
+          IMAGES=("teable-cloud" "teable-sandbox-cloud")
+
+          for REGISTRY in "${REGISTRIES[@]}"; do
+            for IMAGE in "${IMAGES[@]}"; do
+              docker buildx imagetools create \
+                --tag "$REGISTRY/${IMAGE}:prod-${RELEASE_ID}" \
+                "$REGISTRY/${IMAGE}:${RELEASE_ID}"
+            done
+          done
+
   deploy-sandbox:
     name: Deploy Sandbox to ECS
-    needs: prepare
+    needs: [prepare, stamp-prod]
     runs-on: ubuntu-latest
 
     steps:
@@ -111,7 +165,7 @@ jobs:
         with:
           task-definition: sandbox-task-definition.json
           container-name: teable-sandbox
-          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-sandbox-cloud:${{ inputs.image_tag }}
+          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-sandbox-cloud:prod-${{ inputs.image_tag }}
 
       - name: Deploy sandbox to ECS service
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
@@ -181,7 +235,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: teable
-          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud:${{ inputs.image_tag }}
+          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud:prod-${{ inputs.image_tag }}
 
       - name: Run database migration as one-off task
         run: |
@@ -314,13 +368,28 @@ jobs:
             done
           done
 
+# Aliyun receives images ONLY at release time. The pinned release-id must
+  # ship alongside latest: teable.cn (manual-sealos-deploy) deploys that
+  # pinned tag from Aliyun, and the sync's cloud lane also carries the
+  # canonical agent tag that CN sandboxes pull.
   sync-aliyun:
     needs: promote-latest
     if: needs.promote-latest.result == 'success'
     uses: ./.github/workflows/sync-aliyun.yaml
     with:
       edition: cloud
-      tags: "latest"
+      tags: "latest,${{ inputs.image_tag }}"
+    secrets: inherit
+
+  # Preheat CN sandbox-agent nodes as soon as the agent tag lands on Aliyun.
+  # Best-effort: not part of the notify gating — a preheat miss only costs
+  # first-spawn latency.
+  preheat-sandbox-agent:
+    needs: sync-aliyun
+    if: needs.sync-aliyun.result == 'success'
+    uses: ./.github/workflows/preheat-sandbox-agent-cloud.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
     secrets: inherit
 
   notify:

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -88,11 +88,45 @@ jobs:
     outputs:
       start_time: ${{ steps.start_time.outputs.start }}
       image_tag: ${{ inputs.image_tag }}
+      staging_tag: ${{ steps.resolve.outputs.staging_tag }}
 
     steps:
       - name: Record start time
         id: start_time
         run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Resolve staging registry tag
+        id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          # Records and automation identify a build by its release id
+          # (release.<ts>.<seq>); the registry tag of a staging build is the
+          # derived beta-<ts>.<seq> twin. Builds from before the channel
+          # split were pushed as release.* directly, so fall back to the
+          # input tag when the beta twin is absent on ECR.
+          case "$INPUT_TAG" in
+            release.*) CANDIDATE="beta-${INPUT_TAG#release.}" ;;
+            *)         CANDIDATE="$INPUT_TAG" ;;
+          esac
+          if aws ecr describe-images --region us-west-2 \
+               --repository-name teable/teable-cloud \
+               --image-ids imageTag="$CANDIDATE" >/dev/null 2>&1; then
+            STAGING_TAG="$CANDIDATE"
+          else
+            echo "beta twin ${CANDIDATE} not on ECR, falling back to ${INPUT_TAG}"
+            STAGING_TAG="$INPUT_TAG"
+          fi
+          echo "staging_tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Deploying registry tag: ${STAGING_TAG}"
 
   deploy-sandbox:
     name: Deploy Sandbox to Staging ECS
@@ -127,7 +161,7 @@ jobs:
         with:
           task-definition: sandbox-task-definition.json
           container-name: sandbox
-          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-sandbox-cloud:${{ inputs.image_tag }}
+          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-sandbox-cloud:${{ needs.prepare.outputs.staging_tag }}
 
       - name: Deploy sandbox to ECS service
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
@@ -170,7 +204,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: teable
-          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud:${{ inputs.image_tag }}
+          image: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud:${{ needs.prepare.outputs.staging_tag }}
 
       - name: Run database migration as one-off task
         run: |

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -64,11 +64,13 @@ on:
         required: false
 
 jobs:
-  # teable.cn deploys pinned tags from Aliyun, but Aliyun only receives
-  # images at release time (manual-ecs-deploy's sync-aliyun). This job makes
-  # the CN deploy self-sufficient: any tag still missing on Aliyun is copied
-  # from ghcr before kubectl touches anything, so the CN and AI launches can
-  # run in either order. Idempotent — near-instant when the tags are there.
+  # teable.cn deploys official release.<id> tags from Aliyun, but Aliyun
+  # only receives images at release time (manual-ecs-deploy's sync-aliyun).
+  # This job makes the CN launch self-sufficient: if this build was never
+  # released yet, its release.<id> is first stamped on ghcr from the
+  # beta-<id> staging twin, then any tag missing on Aliyun is copied over —
+  # so the CN and AI launches can run in either order. Idempotent:
+  # near-instant when the tags already exist.
   ensure-aliyun:
     name: Ensure release images on Aliyun
     runs-on: ubuntu-latest
@@ -78,7 +80,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
 
-      - name: Copy any missing images from ghcr
+      - name: Stamp and copy any missing images
         env:
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
           DST_CREDS: ${{ vars.ALI_DOCKER_USERNAME }}:${{ secrets.ALI_DOCKER_PASSWORD }}
@@ -87,32 +89,48 @@ jobs:
           TAG: ${{ inputs.image_tag }}
         run: |
           set -euo pipefail
+          BETA_TAG="beta-${TAG#release.}"
+
+          retry_copy() {
+            local src="$1" dst="$2" dst_creds="$3"
+            for attempt in 1 2 3; do
+              if skopeo copy --all \
+                  --src-creds="$SRC_CREDS" \
+                  --dest-creds="$dst_creds" \
+                  "docker://${src}" "docker://${dst}"; then
+                return 0
+              fi
+              echo "⚠️ attempt ${attempt} failed for ${src}, retrying in 10s"
+              sleep 10
+            done
+            echo "❌ failed to copy ${src} -> ${dst}"
+            return 1
+          }
+
           # The agent is included because CN sandboxes pull
-          # <aliyun prefix>:<the app's release id> at spawn time.
+          # <aliyun prefix>:<the app's release id> at spawn time; it always
+          # carries the release tag already (tagged at build time).
           for image in teable-cloud teable-sandbox-cloud teable-sandbox-agent; do
             if skopeo inspect --raw --creds="$DST_CREDS" \
                 "docker://${DST_REGISTRY}/${image}:${TAG}" >/dev/null 2>&1; then
               echo "✅ ${image}:${TAG} already on Aliyun"
               continue
             fi
-            echo "⏫ ${image}:${TAG} missing on Aliyun, copying from ghcr"
-            copied=0
-            for attempt in 1 2 3; do
-              if skopeo copy --all \
-                  --src-creds="$SRC_CREDS" \
-                  --dest-creds="$DST_CREDS" \
-                  "docker://${SRC_REGISTRY}/${image}:${TAG}" \
-                  "docker://${DST_REGISTRY}/${image}:${TAG}"; then
-                copied=1
-                break
-              fi
-              echo "⚠️ attempt ${attempt} failed, retrying in 10s"
-              sleep 10
-            done
-            if [ "$copied" != "1" ]; then
-              echo "❌ failed to copy ${image}:${TAG} to Aliyun"
-              exit 1
+
+            if ! skopeo inspect --raw --creds="$SRC_CREDS" \
+                "docker://${SRC_REGISTRY}/${image}:${TAG}" >/dev/null 2>&1; then
+              echo "⏫ ${image}:${TAG} not stamped yet, stamping from ${BETA_TAG} on ghcr"
+              retry_copy \
+                "${SRC_REGISTRY}/${image}:${BETA_TAG}" \
+                "${SRC_REGISTRY}/${image}:${TAG}" \
+                "$SRC_CREDS"
             fi
+
+            echo "⏫ ${image}:${TAG} missing on Aliyun, copying from ghcr"
+            retry_copy \
+              "${SRC_REGISTRY}/${image}:${TAG}" \
+              "${DST_REGISTRY}/${image}:${TAG}" \
+              "$DST_CREDS"
           done
 
   deploy:

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -64,8 +64,60 @@ on:
         required: false
 
 jobs:
+  # teable.cn deploys pinned tags from Aliyun, but Aliyun only receives
+  # images at release time (manual-ecs-deploy's sync-aliyun). This job makes
+  # the CN deploy self-sufficient: any tag still missing on Aliyun is copied
+  # from ghcr before kubectl touches anything, so the CN and AI launches can
+  # run in either order. Idempotent — near-instant when the tags are there.
+  ensure-aliyun:
+    name: Ensure release images on Aliyun
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Copy any missing images from ghcr
+        env:
+          SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
+          DST_CREDS: ${{ vars.ALI_DOCKER_USERNAME }}:${{ secrets.ALI_DOCKER_PASSWORD }}
+          SRC_REGISTRY: ghcr.io/teableio
+          DST_REGISTRY: registry.cn-shenzhen.aliyuncs.com/teable
+          TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          # The agent is included because CN sandboxes pull
+          # <aliyun prefix>:<the app's release id> at spawn time.
+          for image in teable-cloud teable-sandbox-cloud teable-sandbox-agent; do
+            if skopeo inspect --raw --creds="$DST_CREDS" \
+                "docker://${DST_REGISTRY}/${image}:${TAG}" >/dev/null 2>&1; then
+              echo "✅ ${image}:${TAG} already on Aliyun"
+              continue
+            fi
+            echo "⏫ ${image}:${TAG} missing on Aliyun, copying from ghcr"
+            copied=0
+            for attempt in 1 2 3; do
+              if skopeo copy --all \
+                  --src-creds="$SRC_CREDS" \
+                  --dest-creds="$DST_CREDS" \
+                  "docker://${SRC_REGISTRY}/${image}:${TAG}" \
+                  "docker://${DST_REGISTRY}/${image}:${TAG}"; then
+                copied=1
+                break
+              fi
+              echo "⚠️ attempt ${attempt} failed, retrying in 10s"
+              sleep 10
+            done
+            if [ "$copied" != "1" ]; then
+              echo "❌ failed to copy ${image}:${TAG} to Aliyun"
+              exit 1
+            fi
+          done
+
   deploy:
     name: Deploy to Sealos
+    needs: ensure-aliyun
     runs-on: ubuntu-latest
     outputs:
       start_time: ${{ steps.start_time.outputs.start }}

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -1,5 +1,18 @@
 name: Promote teable EE to latest
 
+# EE stable-channel release. Staging builds publish only to ghcr (pinned
+# release-id + floating beta); this workflow turns a chosen build into the
+# stable release:
+#   1. ghcr: move latest and stamp prod-<release-id> — the permanent marker
+#      that exempts the promoted version (and its co-located release-id tag)
+#      from ghcr-gc.yaml.
+#   2. Docker Hub: copy release-id + latest FROM ghcr. The per-merge sync
+#      ships only the beta channel, so the pinned tag does not exist on
+#      Docker Hub before this runs — promote must copy, not retag.
+#   3. Aliyun EE mirror: latest + release-id, including the canonical agent
+#      tag (the sync's ee lane skips latest for the agent by design).
+#   4. Notify teable-infra (teable-stable-promoted).
+
 on:
   workflow_dispatch:
     inputs:
@@ -13,21 +26,10 @@ on:
 env:
   REGISTRY_GITHUB: ghcr.io/teableio
   REGISTRY_DOCKERHUB: docker.io/teableio
-  CE_IMAGE_SUFFIX: ""
-  EE_IMAGE_SUFFIX: "-ee"
 
 jobs:
   promote-latest:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [app, sandbox]
-        include:
-          - target: app
-            image: teable
-          - target: sandbox
-            image: teable-sandbox
-
     steps:
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
@@ -36,29 +38,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.PACKAGES_KEY }}
 
-      - name: Login to Docker Hub registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKER_HUB_NAME }}
-          password: ${{ secrets.DOCKER_HUB_AK }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Promote release tag to latest
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Promote on ghcr and copy to Docker Hub
         env:
           RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
+          SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
+          DST_CREDS: ${{ vars.DOCKER_HUB_NAME }}:${{ secrets.DOCKER_HUB_AK }}
         run: |
-          REGISTRIES=("${{ env.REGISTRY_GITHUB }}" "${{ env.REGISTRY_DOCKERHUB }}")
-          SUFFIXES=("${{ env.CE_IMAGE_SUFFIX }}" "${{ env.EE_IMAGE_SUFFIX }}")
+          set -euo pipefail
+          IMAGES=(teable teable-ee teable-sandbox teable-sandbox-ee)
 
-          for REGISTRY in "${REGISTRIES[@]}"; do
-            for SUFFIX in "${SUFFIXES[@]}"; do
-              docker buildx imagetools create \
-                --tag "$REGISTRY/${{ matrix.image }}${SUFFIX}:latest" \
-                "$REGISTRY/${{ matrix.image }}${SUFFIX}:${RELEASE_ID}"
+          for image in "${IMAGES[@]}"; do
+            docker buildx imagetools create \
+              --tag "${REGISTRY_GITHUB}/${image}:latest" \
+              --tag "${REGISTRY_GITHUB}/${image}:prod-${RELEASE_ID}" \
+              "${REGISTRY_GITHUB}/${image}:${RELEASE_ID}"
+
+            for tag in "${RELEASE_ID}" latest; do
+              skopeo copy --all \
+                --src-creds="$SRC_CREDS" \
+                --dest-creds="$DST_CREDS" \
+                "docker://${REGISTRY_GITHUB}/${image}:${RELEASE_ID}" \
+                "docker://${REGISTRY_DOCKERHUB}/${image}:${tag}"
             done
           done
+
+          # The agent needs no promote step: its pinned release tags ship to
+          # Docker Hub on every merge (running apps pull them at sandbox
+          # spawn) and the ghcr package is exempt from GC for the same
+          # reason. Aliyun gets the agent release tag via sync-aliyun below.
 
   sync-aliyun:
     needs: promote-latest
@@ -66,7 +81,7 @@ jobs:
     uses: ./.github/workflows/sync-aliyun.yaml
     with:
       edition: ee
-      tags: "latest"
+      tags: "latest,${{ github.event.client_payload.release_id || inputs.release_id }}"
     secrets: inherit
 
   notify-infra:

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -1,17 +1,18 @@
 name: Promote teable EE to latest
 
-# EE stable-channel release. Staging builds publish only to ghcr (pinned
-# release-id + floating beta); this workflow turns a chosen build into the
-# stable release:
-#   1. ghcr: move latest and stamp prod-<release-id> — the permanent marker
-#      that exempts the promoted version (and its co-located release-id tag)
-#      from ghcr-gc.yaml.
-#   2. Docker Hub: copy release-id + latest FROM ghcr. The per-merge sync
-#      ships only the beta channel, so the pinned tag does not exist on
-#      Docker Hub before this runs — promote must copy, not retag.
-#   3. Aliyun EE mirror: latest + release-id, including the canonical agent
-#      tag (the sync's ee lane skips latest for the agent by design).
+# EE stable-channel release. A staging build's app image lives in the
+# INTERNAL teable-staging twin as beta-<id> (the public teable/teable-ee
+# packages only ever show official releases); the sandbox stages in place.
+# Promotion turns a chosen build into the official release:
+#   1. ghcr: stamp release.<id> on the public packages from the staging
+#      source (skip if already stamped — re-promotes work after the beta
+#      twin is reaped), then move latest.
+#   2. Docker Hub: copy release.<id> + latest from ghcr (the per-merge sync
+#      ships only the floating beta channel).
+#   3. Aliyun EE mirror: latest + release.<id>, including the canonical
+#      agent tag (the sync's ee lane skips latest for the agent by design).
 #   4. Notify teable-infra (teable-stable-promoted).
+#   5. Reap old beta-* staging versions (keep a small cushion).
 
 on:
   workflow_dispatch:
@@ -26,6 +27,7 @@ on:
 env:
   REGISTRY_GITHUB: ghcr.io/teableio
   REGISTRY_DOCKERHUB: docker.io/teableio
+  RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
 
 jobs:
   promote-latest:
@@ -46,34 +48,53 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
 
-      - name: Promote on ghcr and copy to Docker Hub
+      - name: Stamp release on ghcr and copy to Docker Hub
         env:
-          RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
           DST_CREDS: ${{ vars.DOCKER_HUB_NAME }}:${{ secrets.DOCKER_HUB_AK }}
         run: |
           set -euo pipefail
-          IMAGES=(teable teable-ee teable-sandbox teable-sandbox-ee)
+          BETA_TAG="beta-${RELEASE_ID#release.}"
 
-          for image in "${IMAGES[@]}"; do
+          # target -> "staging-source release-image alias-image"
+          SPECS=(
+            "teable-staging teable teable-ee"
+            "teable-sandbox teable-sandbox teable-sandbox-ee"
+          )
+
+          for spec in "${SPECS[@]}"; do
+            read -r STAGING RELEASE ALIAS <<< "$spec"
+
+            # Stamp the official tag from the staging source unless a prior
+            # promote already did (the beta twin may be reaped by then).
+            if ! docker buildx imagetools inspect \
+                "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" >/dev/null 2>&1; then
+              docker buildx imagetools create \
+                --tag "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" \
+                "${REGISTRY_GITHUB}/${STAGING}:${BETA_TAG}"
+            fi
+
             docker buildx imagetools create \
-              --tag "${REGISTRY_GITHUB}/${image}:latest" \
-              --tag "${REGISTRY_GITHUB}/${image}:prod-${RELEASE_ID}" \
-              "${REGISTRY_GITHUB}/${image}:${RELEASE_ID}"
+              --tag "${REGISTRY_GITHUB}/${RELEASE}:latest" \
+              --tag "${REGISTRY_GITHUB}/${ALIAS}:${RELEASE_ID}" \
+              --tag "${REGISTRY_GITHUB}/${ALIAS}:latest" \
+              "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}"
 
-            for tag in "${RELEASE_ID}" latest; do
-              skopeo copy --all \
-                --src-creds="$SRC_CREDS" \
-                --dest-creds="$DST_CREDS" \
-                "docker://${REGISTRY_GITHUB}/${image}:${RELEASE_ID}" \
-                "docker://${REGISTRY_DOCKERHUB}/${image}:${tag}"
+            for image in "$RELEASE" "$ALIAS"; do
+              for tag in "${RELEASE_ID}" latest; do
+                skopeo copy --all \
+                  --src-creds="$SRC_CREDS" \
+                  --dest-creds="$DST_CREDS" \
+                  "docker://${REGISTRY_GITHUB}/${image}:${RELEASE_ID}" \
+                  "docker://${REGISTRY_DOCKERHUB}/${image}:${tag}"
+              done
             done
           done
 
-          # The agent needs no promote step: its pinned release tags ship to
-          # Docker Hub on every merge (running apps pull them at sandbox
-          # spawn) and the ghcr package is exempt from GC for the same
-          # reason. Aliyun gets the agent release tag via sync-aliyun below.
+          # The agent needs no promote step: it is tagged release.<id> at
+          # build time and its pinned tags ship to Docker Hub on every merge
+          # (running apps pull them at sandbox spawn). Aliyun gets the agent
+          # release tag via sync-aliyun below.
 
   sync-aliyun:
     needs: promote-latest
@@ -93,7 +114,6 @@ jobs:
       - name: Dispatch teable-stable-promoted to teable-infra
         env:
           DISPATCH_TOKEN: ${{ secrets.TEABLE_INFRA_DISPATCH_TOKEN }}
-          RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
         run: |
           curl -fsS -X POST \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
@@ -101,3 +121,28 @@ jobs:
             https://api.github.com/repos/teableio/teable-infra/dispatches \
             -d "{\"event_type\":\"teable-stable-promoted\",\"client_payload\":{\"release_id\":\"${RELEASE_ID}\"}}"
           echo "dispatched teable-stable-promoted release_id=${RELEASE_ID}"
+
+  # With the stable release out, reap old EE staging versions (the
+  # teable-staging twin and the in-place sandbox beta-* tags), keeping a
+  # small cushion. Dry-run until the GHCR_GC_TOKEN delete:packages PAT
+  # exists. Shares the ghcr-gc concurrency group: the cleanup action must
+  # never run twice against the same package.
+  cleanup-beta:
+    name: Reap EE staging versions
+    needs: promote-latest
+    if: needs.promote-latest.result == 'success'
+    concurrency:
+      group: ghcr-gc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old beta versions of the EE staging packages
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        with:
+          token: ${{ secrets.GHCR_GC_TOKEN || secrets.PACKAGES_KEY }}
+          owner: teableio
+          packages: teable-staging,teable-sandbox,teable-sandbox-ee
+          delete-tags: beta-*
+          keep-n-tagged: 5
+          exclude-tags: latest,beta,release.*
+          validate: true
+          dry-run: ${{ secrets.GHCR_GC_TOKEN == '' }}


### PR DESCRIPTION
## Why

Every develop merge currently fans out to 5 registries × 3 tags and has left ~23.6k package versions on ghcr. Decision: **a `release.*` tag means an official release**. Staging builds carry only a derived `beta-<ts>.<seq>` registry tag; launch stamps `release.<id>` and then reaps old betas. Historical versions (all tagged `release.*`) are deliberately left untouched.

## The model

- **Identity vs registry tag**: `release.<ts>.<seq>` stays the build identity everywhere — `BUILD_VERSION` baked into the image, Sentry release, tracking records, the automation payloads, and the tag a running app uses to pull its sandbox agent. Only the *registry* tag of a staging build is the bijective twin `beta-<ts>.<seq>`; workflows map between the two internally, so records/automation/notifications change nothing.
- **Public packages stay clean**: EE app staging builds push to the INTERNAL twin package **`teable-staging`** — the public `teable`/`teable-ee` tag lists only ever show `release.*` + `latest` + the floating `beta` channel (still tracking develop, stamped cross-repo). All other app packages are internal-visibility and stage in place with `beta-*`.
- **Agent exception**: `teable-sandbox-agent` is tagged `release.<id>` on every build and is exempt from all cleanup — every app build (staging or production) pulls `<prefix>:<its own BUILD_VERSION>` at sandbox spawn.

## Per-merge (staging channel) — `build-teable.yaml`

| what | where |
|---|---|
| EE app (multi-arch) | ghcr `teable-staging:beta-<id>` (internal twin) |
| sandbox EE | ghcr `teable-sandbox`/`-ee:beta-<id>` (in place) |
| cloud pair | ghcr `teable-cloud`/`teable-sandbox-cloud:beta-<id>` + ECR `beta-<id>` (AWS staging pulls ECR) |
| agent | ghcr + dockerhub `release.<id>` (runtime contract) |
| beta channel float | ghcr + dockerhub `beta` (develop only) |

No sha tags, no per-merge Aliyun/preheat, no dockerhub pinned app tags. Cloud `latest` moves only at launch.

## At launch

- **`manual-ecs-staging-deploy`**: resolves `release.<id>` → `beta-<id>` (falls back to the input tag for pre-split builds) — automation input unchanged.
- **`manual-ecs-deploy`** (teable.ai): new `stamp-release` job stamps `release.<id>` from `beta-<id>` on ghcr+ECR *before* deploying (idempotent — rollback re-deploys find it stamped and skip, working even after the beta twin is reaped). Then the existing `latest` promote, Aliyun sync widened to `latest,<release.id>`, agent preheat, and a `cleanup-beta` job (cloud packages, keep newest 5; dry-run until `GHCR_GC_TOKEN` exists).
- **`manual-sealos-deploy`** (teable.cn): `ensure-aliyun` job — stamps ghcr `release.<id>` from the beta twin if this build was never released, then copies any missing tags to Aliyun. CN/AI launch order no longer matters.
- **`promote-latest-ee`** (EE stable): stamps `release.<id>` on public `teable`/`teable-ee` from the `teable-staging` twin, moves `latest`, copies `release.<id>`+`latest` to Docker Hub, Aliyun `latest,<release.id>`, notify-infra, then reaps EE staging versions.

## Semantic notes

1. Aliyun `beta` freezes (no per-merge EE mirror) — say the word if the CN beta channel matters.
2. The dead `promote-cloud` dispatch event stays dead (cloud promotion = the production deploy).
3. First unreleased build after merge deploys staging from `beta-*`; the first launch stamps the official tag. Old builds keep working via fallbacks.

## Validation

- All five files pass YAML parse; rehearsal run on this branch (see PR comments) verifies: twin-package push, single `beta-*` tag, agent `release.*` tag, no floating-tag movement, correct skip matrix.

Companion: #57 (scheduled beta GC backstop). ECR lifecycle policy (expire `beta-` by count, replacing the current tag-blind keep-60 rule that could expire in-service production images) comes last, after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
