### PR TITLE
ci: follow-up fixes for the channel-split launch paths (review findings on #58)

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -182,7 +182,9 @@ jobs:
 
   deploy-app:
     name: Deploy Main to ECS
-    needs: prepare
+    # stamp-release must have produced the release.<id> tag before the
+    # migration one-off task or the service tries to pull it.
+    needs: [prepare, stamp-release]
     runs-on: ubuntu-latest
 
     steps:
@@ -400,10 +402,12 @@ jobs:
   # With the release stamped and deployed, the accumulated cloud staging
   # versions have served their purpose: reap beta-* keeping a small cushion
   # for staging rollback. The launched version itself only loses its beta-
-  # tag — the image survives, now carrying release.<id>. Without the
-  # GHCR_GC_TOKEN delete:packages PAT this runs as a dry-run. Shares the
-  # ghcr-gc concurrency group: the cleanup action must never run twice
-  # against the same package.
+  # tag — the image survives, now carrying release.<id>. Skips entirely
+  # until the GHCR_GC_TOKEN PAT (write:packages + delete:packages) exists:
+  # the action's multi-tag untagging PUT is not dry-run-gated, so an
+  # unarmed dry-run fallback with a write-capable token would not actually
+  # be read-only. Shares the ghcr-gc concurrency group: the cleanup action
+  # must never run twice against the same package.
   cleanup-beta:
     name: Reap cloud staging versions
     needs: [deploy-sandbox, deploy-app, promote-latest]
@@ -412,17 +416,29 @@ jobs:
       group: ghcr-gc
     runs-on: ubuntu-latest
     steps:
+      - name: Check arming token
+        id: gate
+        env:
+          GC_TOKEN: ${{ secrets.GHCR_GC_TOKEN }}
+        run: |
+          if [ -n "$GC_TOKEN" ]; then
+            echo "armed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "armed=false" >> "$GITHUB_OUTPUT"
+            echo "GHCR_GC_TOKEN not set — skipping staging cleanup"
+          fi
+
       - name: Delete old beta versions of the cloud packages
+        if: steps.gate.outputs.armed == 'true'
         uses: dataaxiom/ghcr-cleanup-action@v1.2.2
         with:
-          token: ${{ secrets.GHCR_GC_TOKEN || secrets.PACKAGES_KEY }}
+          token: ${{ secrets.GHCR_GC_TOKEN }}
           owner: teableio
           packages: teable-cloud,teable-sandbox-cloud
           delete-tags: beta-*
           keep-n-tagged: 5
           exclude-tags: latest,release.*
           validate: true
-          dry-run: ${{ secrets.GHCR_GC_TOKEN == '' }}
 
   notify:
     name: Record Deployment in Teable

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -62,6 +62,13 @@ on:
         required: true
       TEABLE_API_TOKEN:
         required: false
+      # Used by the ensure-aliyun job (ghcr pull / Aliyun push) — callers
+      # not using `secrets: inherit` must pass these for the self-heal
+      # copy to work.
+      PACKAGES_KEY:
+        required: false
+      ALI_DOCKER_PASSWORD:
+        required: false
 
 jobs:
   # teable.cn deploys official release.<id> tags from Aliyun, but Aliyun

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -91,10 +91,18 @@ jobs:
             done
           done
 
-          # The agent needs no promote step: it is tagged release.<id> at
-          # build time and its pinned tags ship to Docker Hub on every merge
-          # (running apps pull them at sandbox spawn). Aliyun gets the agent
-          # release tag via sync-aliyun below.
+          # The agent already carries release.<id> on ghcr (tagged at build
+          # time), and develop merges ship it to Docker Hub per merge — but
+          # branch/hotfix builds skip that beta-channel sync, so copy it
+          # here too (idempotent) to guarantee any promoted id has its
+          # agent on Docker Hub: self-hosted apps pull
+          # <prefix>:<their BUILD_VERSION> at sandbox spawn. Aliyun gets
+          # the agent release tag via sync-aliyun below.
+          skopeo copy --all \
+            --src-creds="$SRC_CREDS" \
+            --dest-creds="$DST_CREDS" \
+            "docker://${REGISTRY_GITHUB}/teable-sandbox-agent:${RELEASE_ID}" \
+            "docker://${REGISTRY_DOCKERHUB}/teable-sandbox-agent:${RELEASE_ID}"
 
   sync-aliyun:
     needs: promote-latest
@@ -124,9 +132,12 @@ jobs:
 
   # With the stable release out, reap old EE staging versions (the
   # teable-staging twin and the in-place sandbox beta-* tags), keeping a
-  # small cushion. Dry-run until the GHCR_GC_TOKEN delete:packages PAT
-  # exists. Shares the ghcr-gc concurrency group: the cleanup action must
-  # never run twice against the same package.
+  # small cushion. Skips entirely until the GHCR_GC_TOKEN PAT
+  # (write:packages + delete:packages) exists: the action's multi-tag
+  # untagging PUT is not dry-run-gated, so an unarmed dry-run fallback
+  # with a write-capable token would not actually be read-only. Shares the
+  # ghcr-gc concurrency group: the cleanup action must never run twice
+  # against the same package.
   cleanup-beta:
     name: Reap EE staging versions
     needs: promote-latest
@@ -135,14 +146,26 @@ jobs:
       group: ghcr-gc
     runs-on: ubuntu-latest
     steps:
+      - name: Check arming token
+        id: gate
+        env:
+          GC_TOKEN: ${{ secrets.GHCR_GC_TOKEN }}
+        run: |
+          if [ -n "$GC_TOKEN" ]; then
+            echo "armed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "armed=false" >> "$GITHUB_OUTPUT"
+            echo "GHCR_GC_TOKEN not set — skipping staging cleanup"
+          fi
+
       - name: Delete old beta versions of the EE staging packages
+        if: steps.gate.outputs.armed == 'true'
         uses: dataaxiom/ghcr-cleanup-action@v1.2.2
         with:
-          token: ${{ secrets.GHCR_GC_TOKEN || secrets.PACKAGES_KEY }}
+          token: ${{ secrets.GHCR_GC_TOKEN }}
           owner: teableio
           packages: teable-staging,teable-sandbox,teable-sandbox-ee
           delete-tags: beta-*
           keep-n-tagged: 5
           exclude-tags: latest,beta,release.*
           validate: true
-          dry-run: ${{ secrets.GHCR_GC_TOKEN == '' }}


### PR DESCRIPTION
Addresses the Codex findings on #58 (merged) that survived triage:

1. **deploy-app now `needs: stamp-release`** — real race: on a first launch the migration one-off task and service point at `release.<id>`, which `stamp-release` creates in a parallel job; the sandbox job was gated, the app job wasn't.
2. **`promote-latest-ee` also copies `teable-sandbox-agent:release.<id>` to Docker Hub** (idempotent) — develop merges ship it per merge, but a promoted branch/hotfix build skips the beta-channel sync and would leave self-hosted sandboxes unable to pull their agent.
3. **`manual-sealos-deploy` declares `PACKAGES_KEY`/`ALI_DOCKER_PASSWORD`** as optional `workflow_call` secrets for the `ensure-aliyun` job (callers not using `secrets: inherit`).
4. **`cleanup-beta` jobs skip entirely when `GHCR_GC_TOKEN` is absent** instead of dry-running with the `PACKAGES_KEY` fallback — verified in `dataaxiom/ghcr-cleanup-action@v1.2.2` source (`src/image-deleter.ts performUntagging`): the multi-tag untagging PUT is not dry-run-gated, so that fallback was not actually read-only. Matches the same fix on #57.

Findings triaged as no-change (rationale posted inline on #58): the stamp-source-expired concern (merged `stamp-release` skips when the permanent `release.<id>` exists, so rollbacks never read the reaped beta twin), the preheat-secrets-required path (no `workflow_call` callers exist; dispatch inherits repo secrets), and branch-build sha traceability (branch releases are rare validation runs; the resolved sha is in the run log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)