### PR TITLE
ci: staging cleanup uses PACKAGES_KEY directly — drop the GHCR_GC_TOKEN arming secret

### DIFF
--- a/.github/workflows/ghcr-gc.yaml
+++ b/.github/workflows/ghcr-gc.yaml
@@ -24,7 +24,7 @@ name: GHCR GC
 # delete:packages, repo, write:packages — write matters because untagging
 # a multi-tagged image PUTs a replacement manifest before deleting it).
 # Note that manual dry_run is NOT fully read-only in
-# dataaxiom/ghcr-cleanup-action@v1.2.2: the untagging PUT for
+# dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2: the untagging PUT for
 # multi-tagged delete-tags matches is not dry-run-gated (verified in
 # src/image-deleter.ts performUntagging). With our exclude-tags config,
 # delete-tags matches are single-tagged in practice, so dry_run output is
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clean staging image versions
-        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio
@@ -79,7 +79,7 @@ jobs:
     if: always()
     steps:
       - name: Clean buildcache and agent-base packages
-        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio

--- a/.github/workflows/ghcr-gc.yaml
+++ b/.github/workflows/ghcr-gc.yaml
@@ -23,8 +23,8 @@ name: GHCR GC
 # Token: PACKAGES_KEY (probed 2026-07-18: classic PAT with
 # delete:packages, repo, write:packages — write matters because untagging
 # a multi-tagged image PUTs a replacement manifest before deleting it).
-# Note that manual dry_run is NOT fully read-only in
-# dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2: the untagging PUT for
+# Note that manual dry_run is NOT fully read-only in the cleanup action
+# (v1.2.2, SHA-pinned below): the untagging PUT for
 # multi-tagged delete-tags matches is not dry-run-gated (verified in
 # src/image-deleter.ts performUntagging). With our exclude-tags config,
 # delete-tags matches are single-tagged in practice, so dry_run output is

--- a/.github/workflows/ghcr-gc.yaml
+++ b/.github/workflows/ghcr-gc.yaml
@@ -20,18 +20,16 @@ name: GHCR GC
 # release id> at sandbox spawn, so agent release tags must stay pullable
 # for as long as ANY deployment still runs that app build.
 #
-# Arming: requires a classic PAT with write:packages + delete:packages in
-# GHCR_GC_TOKEN (write is needed because untagging a multi-tagged image
-# PUTs a replacement manifest before deleting it). Until that secret
-# exists, every job here SKIPS entirely — deliberately not a dry-run
-# fallback: in dataaxiom/ghcr-cleanup-action@v1.2.2 the untagging PUT for
-# multi-tagged delete-tags matches is NOT gated by dry-run (verified in
-# src/image-deleter.ts performUntagging), so an unarmed "dry run" with a
-# write-capable fallback token could still move tags. With our
-# exclude-tags config, delete-tags matches are single-tagged in practice,
-# but skip-when-unarmed removes the hazard class outright. For the same
-# reason, treat manual dry_run output as trustworthy only for
-# single-tagged matches.
+# Token: PACKAGES_KEY (probed 2026-07-18: classic PAT with
+# delete:packages, repo, write:packages — write matters because untagging
+# a multi-tagged image PUTs a replacement manifest before deleting it).
+# Note that manual dry_run is NOT fully read-only in
+# dataaxiom/ghcr-cleanup-action@v1.2.2: the untagging PUT for
+# multi-tagged delete-tags matches is not dry-run-gated (verified in
+# src/image-deleter.ts performUntagging). With our exclude-tags config,
+# delete-tags matches are single-tagged in practice, so dry_run output is
+# trustworthy — but keep that caveat in mind before loosening the
+# excludes.
 
 on:
   schedule:
@@ -58,23 +56,10 @@ jobs:
   gc-staging-images:
     runs-on: ubuntu-latest
     steps:
-      - name: Check arming token
-        id: gate
-        env:
-          GC_TOKEN: ${{ secrets.GHCR_GC_TOKEN }}
-        run: |
-          if [ -n "$GC_TOKEN" ]; then
-            echo "armed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "armed=false" >> "$GITHUB_OUTPUT"
-            echo "GHCR_GC_TOKEN not set — skipping GC (see workflow header)"
-          fi
-
       - name: Clean staging image versions
-        if: steps.gate.outputs.armed == 'true'
         uses: dataaxiom/ghcr-cleanup-action@v1.2.2
         with:
-          token: ${{ secrets.GHCR_GC_TOKEN }}
+          token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio
           packages: teable-staging,teable-sandbox,teable-sandbox-ee,teable-cloud,teable-sandbox-cloud
           delete-tags: beta-*
@@ -93,23 +78,10 @@ jobs:
     needs: gc-staging-images
     if: always()
     steps:
-      - name: Check arming token
-        id: gate
-        env:
-          GC_TOKEN: ${{ secrets.GHCR_GC_TOKEN }}
-        run: |
-          if [ -n "$GC_TOKEN" ]; then
-            echo "armed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "armed=false" >> "$GITHUB_OUTPUT"
-            echo "GHCR_GC_TOKEN not set — skipping GC (see workflow header)"
-          fi
-
       - name: Clean buildcache and agent-base packages
-        if: steps.gate.outputs.armed == 'true'
         uses: dataaxiom/ghcr-cleanup-action@v1.2.2
         with:
-          token: ${{ secrets.GHCR_GC_TOKEN }}
+          token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio
           packages: teable-buildcache,teable-sandbox-agent-base
           exclude-tags: latest,deps-*,base-*

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -402,11 +402,9 @@ jobs:
   # With the release stamped and deployed, the accumulated cloud staging
   # versions have served their purpose: reap beta-* keeping a small cushion
   # for staging rollback. The launched version itself only loses its beta-
-  # tag — the image survives, now carrying release.<id>. Skips entirely
-  # until the GHCR_GC_TOKEN PAT (write:packages + delete:packages) exists:
-  # the action's multi-tag untagging PUT is not dry-run-gated, so an
-  # unarmed dry-run fallback with a write-capable token would not actually
-  # be read-only. Shares the ghcr-gc concurrency group: the cleanup action
+  # tag — the image survives, now carrying release.<id>. PACKAGES_KEY has
+  # the needed scopes (delete:packages + write:packages, probed
+  # 2026-07-18). Shares the ghcr-gc concurrency group: the cleanup action
   # must never run twice against the same package.
   cleanup-beta:
     name: Reap cloud staging versions
@@ -416,23 +414,10 @@ jobs:
       group: ghcr-gc
     runs-on: ubuntu-latest
     steps:
-      - name: Check arming token
-        id: gate
-        env:
-          GC_TOKEN: ${{ secrets.GHCR_GC_TOKEN }}
-        run: |
-          if [ -n "$GC_TOKEN" ]; then
-            echo "armed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "armed=false" >> "$GITHUB_OUTPUT"
-            echo "GHCR_GC_TOKEN not set — skipping staging cleanup"
-          fi
-
       - name: Delete old beta versions of the cloud packages
-        if: steps.gate.outputs.armed == 'true'
         uses: dataaxiom/ghcr-cleanup-action@v1.2.2
         with:
-          token: ${{ secrets.GHCR_GC_TOKEN }}
+          token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio
           packages: teable-cloud,teable-sandbox-cloud
           delete-tags: beta-*

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -415,7 +415,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old beta versions of the cloud packages
-        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -132,12 +132,10 @@ jobs:
 
   # With the stable release out, reap old EE staging versions (the
   # teable-staging twin and the in-place sandbox beta-* tags), keeping a
-  # small cushion. Skips entirely until the GHCR_GC_TOKEN PAT
-  # (write:packages + delete:packages) exists: the action's multi-tag
-  # untagging PUT is not dry-run-gated, so an unarmed dry-run fallback
-  # with a write-capable token would not actually be read-only. Shares the
-  # ghcr-gc concurrency group: the cleanup action must never run twice
-  # against the same package.
+  # small cushion. PACKAGES_KEY has the needed scopes (delete:packages +
+  # write:packages, probed 2026-07-18). Shares the ghcr-gc concurrency
+  # group: the cleanup action must never run twice against the same
+  # package.
   cleanup-beta:
     name: Reap EE staging versions
     needs: promote-latest
@@ -146,23 +144,10 @@ jobs:
       group: ghcr-gc
     runs-on: ubuntu-latest
     steps:
-      - name: Check arming token
-        id: gate
-        env:
-          GC_TOKEN: ${{ secrets.GHCR_GC_TOKEN }}
-        run: |
-          if [ -n "$GC_TOKEN" ]; then
-            echo "armed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "armed=false" >> "$GITHUB_OUTPUT"
-            echo "GHCR_GC_TOKEN not set — skipping staging cleanup"
-          fi
-
       - name: Delete old beta versions of the EE staging packages
-        if: steps.gate.outputs.armed == 'true'
         uses: dataaxiom/ghcr-cleanup-action@v1.2.2
         with:
-          token: ${{ secrets.GHCR_GC_TOKEN }}
+          token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio
           packages: teable-staging,teable-sandbox,teable-sandbox-ee
           delete-tags: beta-*

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old beta versions of the EE staging packages
-        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.PACKAGES_KEY }}
           owner: teableio


### PR DESCRIPTION
A workflow probe confirmed `PACKAGES_KEY` (tea-artist classic PAT) already carries exactly the scopes the cleanup action needs:

```
x-oauth-scopes: delete:packages, repo, write:packages
```

So the separate `GHCR_GC_TOKEN` arming secret bought nothing but an extra step. All three cleanup sites (`ghcr-gc.yaml` ×2, `manual-ecs-deploy` / `promote-latest-ee` `cleanup-beta`) now use `PACKAGES_KEY` directly and run unconditionally.

Going live immediately is inherently safe: the `beta-*` namespace started today, so nothing is old enough for the 14-day schedule nor plentiful enough for the keep-5 launch cushion — first actual deletions are days away, under rules already dry-run-validated. The v1.2.2 dry-run/multi-tag caveat note stays in the ghcr-gc header for future maintainers (our exclude-tags keep matches single-tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)