### PR TITLE
ci: publish-release-note — human-reviewed notes ship to GitHub Release, ghcr and Docker Hub

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -410,6 +410,9 @@ jobs:
     name: Reap cloud staging versions
     needs: [deploy-sandbox, deploy-app, promote-latest]
     if: needs.deploy-sandbox.result == 'success' && needs.deploy-app.result == 'success'
+    # Housekeeping must never mark a successful production deploy as
+    # failed — the scheduled ghcr-gc backstop catches misses.
+    continue-on-error: true
     concurrency:
       group: ghcr-gc
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -147,6 +147,10 @@ jobs:
     name: Reap EE staging versions
     needs: promote-latest
     if: needs.promote-latest.result == 'success'
+    # Post-promotion housekeeping must never fail the promote (callers like
+    # publish-release-note gate on this workflow's result, and the images
+    # are already live) — the scheduled ghcr-gc backstop catches misses.
+    continue-on-error: true
     concurrency:
       group: ghcr-gc
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -23,6 +23,13 @@ on:
         type: string
   repository_dispatch:
     types: [promote-ee]
+  # publish-release-note.yaml calls this so the self-host images are
+  # official everywhere BEFORE the release note goes public.
+  workflow_call:
+    inputs:
+      release_id:
+        required: true
+        type: string
 
 env:
   REGISTRY_GITHUB: ghcr.io/teableio

--- a/.github/workflows/publish-release-note.yaml
+++ b/.github/workflows/publish-release-note.yaml
@@ -1,0 +1,268 @@
+name: Publish Release Note
+
+# The single exit through which a reviewed release note reaches the public.
+# Triggered by the Teable Releases table automation AFTER the releaser has
+# confirmed the "我已 Review" dialog on the DeployAI button. Order matters:
+#
+#   1. promote-ee  — the self-host images (teable/teable-ee + sandbox +
+#      agent) become official on ghcr/dockerhub/aliyun FIRST, so nobody
+#      reads an announcement for an image tag that does not exist yet.
+#      (The cloud production deploy runs in parallel from its own
+#      dispatch; the self-host announcement does not depend on it.)
+#   2. publish     — reads the CURRENT "Release note" field of the given
+#      record (whatever the human left there is what ships) and pushes it
+#      to three places:
+#        - GitHub Release on teableio/teable (markdown, make_latest)
+#        - ghcr version descriptions for teable/teable-ee (plain-text
+#          list via an index annotation re-stamp of release.<id>)
+#        - Docker Hub "What's New" block in the teable/teable-ee repo
+#          overviews (plain-text list, newest 5 kept)
+#      Every step is idempotent — re-running the button re-publishes.
+#   3. Failures ping Feishu only. Deployment status fields/notifications
+#      are owned by the deploy workflows and are deliberately untouched.
+#
+# dry_run (manual dispatch only): skips promote-ee and all writes, prints
+# exactly what would be published — safe rehearsal against any record.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_id:
+        description: 'Release id, e.g. release.2026-04-20T10-38-57Z.1507'
+        required: true
+        type: string
+      record_id:
+        description: 'Releases table record id holding the reviewed note'
+        required: true
+        type: string
+      dry_run:
+        description: 'Print what would be published without writing anywhere'
+        required: false
+        default: false
+        type: boolean
+  repository_dispatch:
+    types: [publish-release-note]
+
+env:
+  RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
+  RECORD_ID: ${{ github.event.client_payload.record_id || inputs.record_id }}
+  OSS_REPO: teableio/teable
+  RELEASES_TABLE: tblAhVLOxNtvkaF1ii5
+
+jobs:
+  promote-ee:
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    uses: ./.github/workflows/promote-latest-ee.yaml
+    with:
+      release_id: ${{ github.event.client_payload.release_id || inputs.release_id }}
+    secrets: inherit
+
+  publish:
+    needs: promote-ee
+    # skipped promote == dry_run rehearsal; anything else requires success.
+    if: always() && (needs.promote-ee.result == 'success' || needs.promote-ee.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve dry-run mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}" = "true" ]; then
+            echo "dry=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::DRY RUN — nothing will be written"
+          else
+            echo "dry=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch the reviewed note from the Releases table
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -fsS -H "Authorization: Bearer ${TEABLE_API_TOKEN}" \
+            "https://app.teable.ai/api/table/${RELEASES_TABLE}/record/${RECORD_ID}?fieldKeyType=name" \
+            > record.json
+
+          jq -r '.fields["Release note"] // empty' record.json > note.md
+          if [ ! -s note.md ]; then
+            echo "::error::Record ${RECORD_ID} has an empty Release note — nothing to publish"
+            exit 1
+          fi
+
+          # Plain-text rendition for ghcr/Docker Hub: drop markdown weight,
+          # keep it a bare line list.
+          python3 - <<'EOF'
+          import re
+          text = open('note.md').read()
+          out = []
+          for line in text.splitlines():
+              line = line.rstrip()
+              line = re.sub(r'^#{1,6}\s*', '', line)          # headings -> text
+              line = re.sub(r'^\s*[-*]\s+', '- ', line)       # bullets -> "- "
+              line = line.replace('**', '').replace('`', '')  # bold/code markers
+              line = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', line)  # links -> text
+              out.append(line)
+          plain = '\n'.join(out)
+          plain = re.sub(r'\n{3,}', '\n\n', plain).strip()
+          open('note.txt', 'w').write(plain + '\n')
+          EOF
+
+          echo "── note.md ──"; cat note.md
+          echo "── note.txt ──"; cat note.txt
+
+      - name: Upsert GitHub release on the open-source repo
+        env:
+          GH_TOKEN: ${{ secrets.PACKAGES_KEY }}
+          DRY: ${{ steps.mode.outputs.dry }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY" = "true" ]; then
+            echo "[dry-run] would upsert ${OSS_REPO} release ${RELEASE_ID} (make_latest) with note.md"
+            exit 0
+          fi
+
+          target_sha="$(gh api "repos/${OSS_REPO}/git/ref/heads/develop" -q .object.sha)"
+
+          if ! gh api "repos/${OSS_REPO}/git/ref/tags/${RELEASE_ID}" >/dev/null 2>&1; then
+            gh api "repos/${OSS_REPO}/git/refs" --method POST \
+              --field ref="refs/tags/${RELEASE_ID}" \
+              --field sha="${target_sha}"
+          fi
+
+          payload="$(jq -nc \
+            --arg tag "${RELEASE_ID}" \
+            --rawfile body note.md \
+            '{tag_name: $tag, name: $tag, body: $body, draft: false, prerelease: false, make_latest: "true"}')"
+
+          existing_id="$(gh api "repos/${OSS_REPO}/releases/tags/${RELEASE_ID}" -q .id 2>/dev/null || true)"
+          if [ -n "$existing_id" ]; then
+            echo "$payload" | gh api "repos/${OSS_REPO}/releases/${existing_id}" --method PATCH --input - >/dev/null
+            echo "Updated existing release ${existing_id}"
+          else
+            echo "$payload" | gh api "repos/${OSS_REPO}/releases" --method POST --input - >/dev/null
+            echo "Created release ${RELEASE_ID}"
+          fi
+
+      - name: Login to GitHub container registry
+        if: steps.mode.outputs.dry == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PACKAGES_KEY }}
+
+      - name: Set up Docker Buildx
+        if: steps.mode.outputs.dry == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      # ghcr shows a per-version description sourced from the
+      # org.opencontainers.image.description annotation on the manifest
+      # index. Re-create the release.<id> tag on itself with the
+      # annotation: blobs are reused, the tag moves to the annotated index
+      # (the old index becomes an untagged orphan — harmless).
+      - name: Stamp ghcr version descriptions
+        env:
+          DRY: ${{ steps.mode.outputs.dry }}
+        run: |
+          set -euo pipefail
+          DESC="$(cat note.txt)"
+          for image in teable teable-ee; do
+            ref="ghcr.io/teableio/${image}:${RELEASE_ID}"
+            if [ "$DRY" = "true" ]; then
+              echo "[dry-run] would re-stamp ${ref} with description annotation"
+              continue
+            fi
+            docker buildx imagetools create \
+              --annotation "index:org.opencontainers.image.description=${DESC}" \
+              --tag "${ref}" \
+              "${ref}"
+          done
+
+      - name: Update Docker Hub What's New
+        env:
+          DRY: ${{ steps.mode.outputs.dry }}
+          HUB_USER: ${{ vars.DOCKER_HUB_NAME }}
+          HUB_TOKEN: ${{ secrets.DOCKER_HUB_AK }}
+        run: |
+          set -euo pipefail
+          JWT="$(jq -nc --arg u "$HUB_USER" --arg p "$HUB_TOKEN" '{username:$u,password:$p}' \
+            | curl -fsS -X POST -H 'Content-Type: application/json' -d @- \
+                https://hub.docker.com/v2/users/login | jq -r .token)"
+
+          for repo in teable teable-ee; do
+            curl -fsS -H "Authorization: JWT ${JWT}" \
+              "https://hub.docker.com/v2/repositories/teableio/${repo}/" \
+              | jq -r '.full_description // ""' > "desc-${repo}.md"
+
+            RELEASE_ID="$RELEASE_ID" python3 - "desc-${repo}.md" <<'EOF'
+          import os, re, sys
+          path = sys.argv[1]
+          release_id = os.environ['RELEASE_ID']
+          note = open('note.txt').read().strip()
+          desc = open(path).read()
+
+          START, END = '<!-- WHATS-NEW:START -->', '<!-- WHATS-NEW:END -->'
+          entry = f"### {release_id}\n\n{note}\n"
+
+          m = re.search(re.escape(START) + r'(.*?)' + re.escape(END), desc, re.S)
+          entries = []
+          if m:
+              body = m.group(1)
+              entries = [('### ' + e).strip() for e in body.split('### ') if e.strip()]
+              entries = [e for e in entries if not e.startswith(f'### {release_id}')]
+          entries.insert(0, entry.strip())
+          entries = entries[:5]
+
+          block = (
+              f"{START}\n## What's New\n\n" + '\n\n'.join(entries)
+              + f"\n\nAll releases: https://github.com/teableio/teable/releases\n{END}"
+          )
+          if m:
+              desc = desc[:m.start()] + block + desc[m.end():]
+          else:
+              desc = desc.rstrip() + '\n\n' + block + '\n'
+          open(path, 'w').write(desc)
+          EOF
+
+            if [ "$DRY" = "true" ]; then
+              echo "[dry-run] would PATCH docker.io/teableio/${repo} overview:"
+              grep -A6 "WHATS-NEW:START" "desc-${repo}.md" | head -12
+              continue
+            fi
+
+            jq -nc --rawfile d "desc-${repo}.md" '{full_description: $d}' \
+              | curl -fsS -X PATCH -H "Authorization: JWT ${JWT}" \
+                  -H 'Content-Type: application/json' -d @- \
+                  "https://hub.docker.com/v2/repositories/teableio/${repo}/" >/dev/null
+            echo "Updated docker.io/teableio/${repo} overview"
+          done
+
+  notify-failure:
+    needs: [promote-ee, publish]
+    if: always() && (needs.promote-ee.result == 'failure' || needs.publish.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Feishu failure notification
+        env:
+          STAGE: ${{ needs.promote-ee.result == 'failure' && 'promote-ee(EE 镜像盖章/分发)' || 'publish(渠道发布)' }}
+        run: |
+          card_payload=$(jq -n \
+            --arg title "❌ Release note 发布失败 ${RELEASE_ID}" \
+            --arg stage "$STAGE" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              "msg_type": "interactive",
+              "card": {
+                "header": {
+                  "title": { "tag": "plain_text", "content": $title },
+                  "template": "red"
+                },
+                "elements": [
+                  { "tag": "div", "text": { "tag": "lark_md", "content": ("**失败阶段**: " + $stage + "\n线上部署状态不受影响；修复后重按 DeployAI 或手动 dispatch publish-release-note 重发。\n[查看运行](" + $url + ")") } }
+                ]
+              }
+            }')
+          curl -fsS -X POST \
+            'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
+            -H 'Content-Type: application/json' \
+            -d "$card_payload" >/dev/null
+          echo "Feishu failure notification sent"

--- a/.github/workflows/publish-release-note.yaml
+++ b/.github/workflows/publish-release-note.yaml
@@ -201,14 +201,21 @@ jobs:
           desc = open(path).read()
 
           START, END = '<!-- WHATS-NEW:START -->', '<!-- WHATS-NEW:END -->'
-          entry = f"### {release_id}\n\n{note}\n"
+          entry = f"### {release_id}\n\n{note}"
 
           m = re.search(re.escape(START) + r'(.*?)' + re.escape(END), desc, re.S)
           entries = []
           if m:
               body = m.group(1)
-              entries = [('### ' + e).strip() for e in body.split('### ') if e.strip()]
-              entries = [e for e in entries if not e.startswith(f'### {release_id}')]
+              # Only real entries survive the rebuild: the block heading and
+              # the All-releases footer are regenerated below, so capture
+              # strictly "### release.*" sections and strip any footer text
+              # that rides along inside the last one.
+              raw = re.findall(r'(?ms)^### release\..*?(?=^### release\.|\Z)', body)
+              for e in raw:
+                  e = re.sub(r'\n+All releases:.*$', '', e, flags=re.S).strip()
+                  if e and not e.startswith(f'### {release_id}'):
+                      entries.append(e)
           entries.insert(0, entry.strip())
           entries = entries[:5]
 
@@ -238,7 +245,8 @@ jobs:
 
   notify-failure:
     needs: [promote-ee, publish]
-    if: always() && (needs.promote-ee.result == 'failure' || needs.publish.result == 'failure')
+    # dry-run rehearsals are side-effect-free by contract — no alerts.
+    if: always() && !(github.event_name == 'workflow_dispatch' && inputs.dry_run) && (needs.promote-ee.result == 'failure' || needs.publish.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Send Feishu failure notification


### PR DESCRIPTION
The single exit through which a reviewed release note reaches the public. Wired to the DeployAI button flow: the automation's publish step becomes **one dispatch of this workflow** (after the releaser confirms the "我已 Review" dialog).

## Order of operations

1. **`promote-ee` first** (via new `workflow_call` on `promote-latest-ee.yaml`, `secrets: inherit`) — self-host images become official on ghcr/dockerhub/aliyun **before** any announcement, so nobody reads notes for an image tag that doesn't exist. The cloud production deploy runs in parallel from its own dispatch; the self-host announcement deliberately doesn't gate on it.
2. **`publish`** — reads the **current** `Release note` field of the given record (whatever the human left there is what ships):
   - GitHub Release on `teableio/teable` (markdown body, `make_latest`, tag ensured on develop HEAD — same behavior as the existing `publish-release.yml`, executed synchronously so failures are visible)
   - ghcr per-version description for `teable`/`teable-ee`: plain-text list via `org.opencontainers.image.description` **index-annotation re-stamp** of `release.<id>` (blobs reused; old index becomes an untagged orphan)
   - Docker Hub `What's New` marker block in the `teable`/`teable-ee` overviews (plain-text, newest 5 kept, links to GitHub Releases)
3. **Failures → Feishu only** (same webhook as staging deploys). Deploy status fields/notifications are owned by the deploy workflows and stay untouched. Everything is idempotent — re-pressing DeployAI republishes safely.

`dry_run` input (manual dispatch): skips promote and all writes, prints exactly what would publish — used for rehearsal against a historical record.

## Automation change needed (Teable side, after merge)

Replace the current publish steps in the DeployAI automation with one HTTP action:

```
POST https://api.github.com/repos/teableio/teable-enterprise/actions/workflows/publish-release-note.yaml/dispatches
Authorization: token <PACKAGES_KEY>
{"ref":"main","inputs":{"release_id":"<Tag 字段>","record_id":"<记录 ID>"}}
```

## Validation

- Multiline-annotation re-stamp mechanic probed separately against the internal `teable-staging` tag (see PR comment).
- Plain-text conversion + Docker Hub block rewrite covered by `dry_run` rehearsal before first live use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)