### PR TITLE
ci: fix release upsert existence check (first-live-publish failure)

### DIFF
--- a/.github/workflows/publish-release-note.yaml
+++ b/.github/workflows/publish-release-note.yaml
@@ -133,8 +133,15 @@ jobs:
             --rawfile body note.md \
             '{tag_name: $tag, name: $tag, body: $body, draft: false, prerelease: false, make_latest: "true"}')"
 
-          existing_id="$(gh api "repos/${OSS_REPO}/releases/tags/${RELEASE_ID}" -q .id 2>/dev/null || true)"
-          if [ -n "$existing_id" ]; then
+          # Branch on gh's EXIT CODE, not its output: on 404 gh prints the
+          # error JSON to stdout, so `-q .id || true` captures garbage and
+          # sends the upsert down the PATCH path.
+          if release_json="$(gh api "repos/${OSS_REPO}/releases/tags/${RELEASE_ID}" 2>/dev/null)"; then
+            existing_id="$(printf '%s' "$release_json" | jq -r .id)"
+          else
+            existing_id=""
+          fi
+          if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
             echo "$payload" | gh api "repos/${OSS_REPO}/releases/${existing_id}" --method PATCH --input - >/dev/null
             echo "Updated existing release ${existing_id}"
           else


### PR DESCRIPTION
First live publish of `release.2026-07-17T14-54-52Z.2273` failed in the GitHub-release upsert: on 404 `gh api` prints the error JSON to **stdout**, so `-q .id 2>/dev/null || true` captured the whole error body as `existing_id` and the step PATCHed a garbage URL. The tag had already been created; the release was never written.

Fix: branch on gh's exit code (command substitution inside `if`), extract `.id` only from a successful response, and treat `null` as absent. Everything else in the live chain was green (promote-ee full chain incl. aliyun/cleanup/notify-infra; Feishu failure alert fired as designed). Will re-dispatch the publish for 2273 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)