### PR TITLE
Only create Launch records for teable.ai deployments

### DIFF
--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -11,23 +11,23 @@ on:
         required: false
         default: 'Manual'
       release_created_time:
-        description: 'Creation time of the release record that triggered this deploy (ISO 8601)'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         default: ''
       release_record_id:
-        description: 'Cloud release record ID in Teable Releases table'
+        description: 'Deprecated compatibility input; teable.cn does not update Release records'
         required: false
         default: ''
       related_release_record_ids:
-        description: 'Comma-separated Teable release record IDs to link on the launch record'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         default: ''
       refined_changelog:
-        description: 'Reviewed English changelog to store on the launch record'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         default: ''
       refined_changelog_zh:
-        description: 'Reviewed Chinese changelog to store on the launch record'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         default: ''
   workflow_call:
@@ -42,27 +42,27 @@ on:
         type: string
         default: 'Automation'
       release_created_time:
-        description: 'Creation time of the release record that triggered this deploy (ISO 8601)'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         type: string
         default: ''
       release_record_id:
-        description: 'Cloud release record ID in Teable Releases table'
+        description: 'Deprecated compatibility input; teable.cn does not update Release records'
         required: false
         type: string
         default: ''
       related_release_record_ids:
-        description: 'Comma-separated Teable release record IDs to link on the launch record'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         type: string
         default: ''
       refined_changelog:
-        description: 'Reviewed English changelog to store on the launch record'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         type: string
         default: ''
       refined_changelog_zh:
-        description: 'Reviewed Chinese changelog to store on the launch record'
+        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
         required: false
         type: string
         default: ''
@@ -283,84 +283,3 @@ jobs:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: rollout status deployment/teable-cloud
-
-      - name: Record deployment in Teable
-        env:
-          IMAGE_TAG: ${{ inputs.image_tag }}
-          TRIGGER: ${{ inputs.trigger || github.actor }}
-          RELEASE_CREATED_TIME: ${{ inputs.release_created_time }}
-          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
-          RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
-          REFINED_CHANGELOG: ${{ inputs.refined_changelog }}
-          REFINED_CHANGELOG_ZH: ${{ inputs.refined_changelog_zh }}
-        run: |
-          current_time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-          related_release_ids_json=$(printf '%s' "$RELATED_RELEASE_RECORD_IDS" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
-
-          # Build JSON payload using jq to properly escape special characters
-          payload=$(jq -n \
-            --arg date "$current_time" \
-            --arg region "teable.cn" \
-            --arg trigger "$TRIGGER" \
-            --arg snapshot "$RELEASE_CREATED_TIME" \
-            --arg refinedChangelog "$REFINED_CHANGELOG" \
-            --arg refinedChangelogZh "$REFINED_CHANGELOG_ZH" \
-            --argjson relatedReleaseIds "$related_release_ids_json" \
-            '{
-              "fieldKeyType": "dbFieldName",
-              "typecast": true,
-              "records": [
-                {
-                  "fields": {
-                    "date": $date,
-                    "region": $region,
-                    "trigger": $trigger,
-                    "Deploy_snapshot_time": (if $snapshot != "" then $snapshot else null end),
-                    "Related_Releases": (if ($relatedReleaseIds | length) > 0 then $relatedReleaseIds else null end),
-                    "Refined_Changelog": (if $refinedChangelog != "" then $refinedChangelog else null end),
-                    "Refined_Changelog_Zhong_Wen": (if $refinedChangelogZh != "" then $refinedChangelogZh else null end)
-                  }
-                }
-              ]
-            }')
-
-          # Make the API call and capture both response and HTTP status code
-          http_code=$(curl -s -w "%{http_code}" -o /tmp/response.json -X POST 'https://app.teable.ai/api/table/tblmGAFOHrGcy66PaUp/record' \
-            -H 'Authorization: Bearer ${{ secrets.TEABLE_API_TOKEN }}' \
-            -H 'Content-Type: application/json' \
-            -d "$payload")
-
-          response=$(cat /tmp/response.json)
-          echo "Response: $response"
-          echo "HTTP Status Code: $http_code"
-
-          # Check if request was successful
-          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
-            record_id=$(echo "$response" | jq -r '.records[0].id')
-            echo "Created deployment record with ID: ${record_id}"
-
-            if [ -n "$RELEASE_RECORD_ID" ]; then
-              update_payload=$(jq -n \
-                '{
-                  "fieldKeyType": "dbFieldName",
-                  "typecast": true,
-                  "record": {
-                    "fields": {
-                      "status": "Launched"
-                    }
-                  }
-                }')
-
-              update_http_code=$(curl -s -w "%{http_code}" -o /tmp/release-update.json -X PATCH \
-                "https://app.teable.ai/api/table/tblAhVLOxNtvkaF1ii5/record/${RELEASE_RECORD_ID}" \
-                -H 'Authorization: Bearer ${{ secrets.TEABLE_API_TOKEN }}' \
-                -H 'Content-Type: application/json' \
-                -d "$update_payload")
-
-              echo "Updated release record ${RELEASE_RECORD_ID} to Launched: HTTP ${update_http_code}"
-            fi
-          else
-            echo "Error: API request failed with status code $http_code"
-            echo "Response: $response"
-            exit 1
-          fi


### PR DESCRIPTION
## Summary
- stop the teable.cn deployment workflow from creating Launch records
- stop teable.cn deployments from changing the Release status to Launched
- retain legacy workflow inputs during the App rollout for compatibility

Launch records and reviewed changelogs are now owned exclusively by the teable.ai deployment workflow.