### PR TITLE
Track AI and CN launches independently

### DIFF
--- a/.github/scripts/finalize-teable-release.sh
+++ b/.github/scripts/finalize-teable-release.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEABLE_API_TOKEN:?TEABLE_API_TOKEN is required}"
+: "${RELEASE_RECORD_ID:?RELEASE_RECORD_ID is required}"
+: "${PUBLISH_LOCK_ID:?PUBLISH_LOCK_ID is required}"
+: "${TARGET:?TARGET is required}"
+
+if [ "$TARGET" != "ai" ] && [ "$TARGET" != "cn" ]; then
+  echo "Unsupported target: $TARGET"
+  exit 1
+fi
+
+TEABLE_API_BASE="https://app.teable.ai/api"
+RELEASES_TABLE_ID="tblAhVLOxNtvkaF1ii5"
+
+read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-lock.json \
+  "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record/${RELEASE_RECORD_ID}?fieldKeyType=dbFieldName" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}")
+
+if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
+  echo "Failed to read Release publishing metadata: HTTP ${read_http_code}"
+  cat /tmp/release-lock.json
+  exit 1
+fi
+
+release_metadata=$(jq -cer '.fields.Publishing_Metadata | fromjson' /tmp/release-lock.json) || {
+  current_status=$(jq -r '.fields.status // empty' /tmp/release-lock.json)
+  if [ "$current_status" = "Launched" ]; then
+    echo "Release is already fully launched"
+    exit 0
+  fi
+  echo "Release publishing metadata is missing or invalid"
+  exit 1
+}
+
+current_lock_id=$(jq -r '.lockId // empty' <<<"$release_metadata")
+current_state=$(jq -r '.state // empty' <<<"$release_metadata")
+if [ "$current_state" != "launching" ] || [ "$current_lock_id" != "$PUBLISH_LOCK_ID" ]; then
+  echo "Publishing lock changed before ${TARGET} completion was recorded"
+  exit 1
+fi
+
+current_time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+completed_metadata=$(jq -c --arg target "$TARGET" \
+  '.completedTargets = (((.completedTargets // []) + [$target]) | unique)' \
+  <<<"$release_metadata")
+launched_targets=$(jq -c --arg target "$TARGET" \
+  '((.launchedTargets // []) + (.completedTargets // []) + [$target]) | unique' \
+  <<<"$release_metadata")
+all_launched=$(jq -r 'index("ai") != null and index("cn") != null' <<<"$launched_targets")
+has_pending_lock_target=$(jq -r --argjson launched "$launched_targets" \
+  'any((.targets // [])[]; . as $target | ($launched | index($target)) == null)' \
+  <<<"$release_metadata")
+
+if [ "$all_launched" = "true" ]; then
+  release_status="Launched"
+  publishing_metadata="null"
+elif [ "$has_pending_lock_target" = "true" ]; then
+  release_status="Launching"
+  publishing_metadata=$(jq -Rn --arg value "$completed_metadata" '$value')
+else
+  release_status="Released"
+  idle_metadata=$(jq -cn \
+    --argjson launchedTargets "$launched_targets" \
+    --arg updatedAt "$current_time" \
+    '{version: 1, state: "idle", launchedTargets: $launchedTargets, updatedAt: $updatedAt}')
+  publishing_metadata=$(jq -Rn --arg value "$idle_metadata" '$value')
+fi
+
+update_payload=$(jq -n \
+  --arg status "$release_status" \
+  --argjson metadata "$publishing_metadata" \
+  '{
+    "fieldKeyType": "dbFieldName",
+    "typecast": true,
+    "record": {
+      "fields": {
+        "status": $status,
+        "Publishing_Metadata": $metadata
+      }
+    }
+  }')
+
+update_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-update.json -X PATCH \
+  "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record/${RELEASE_RECORD_ID}" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d "$update_payload")
+
+if [ "$update_http_code" -lt 200 ] || [ "$update_http_code" -ge 300 ]; then
+  echo "Failed to update Release progress: HTTP ${update_http_code}"
+  cat /tmp/release-update.json
+  exit 1
+fi
+
+echo "Updated Release ${RELEASE_RECORD_ID} to ${release_status}; launched targets: ${launched_targets}"

--- a/.github/scripts/record-teable-launch.sh
+++ b/.github/scripts/record-teable-launch.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEABLE_API_TOKEN:?TEABLE_API_TOKEN is required}"
+: "${REGION:?REGION is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+TEABLE_API_BASE="https://app.teable.ai/api"
+RELEASES_TABLE_ID="tblAhVLOxNtvkaF1ii5"
+LAUNCHES_TABLE_ID="tblmGAFOHrGcy66PaUp"
+
+case "$REGION" in
+  teable.ai) target="ai" ;;
+  teable.cn) target="cn" ;;
+  *) echo "Unsupported region: $REGION"; exit 1 ;;
+esac
+
+if [ -n "${RELEASE_RECORD_ID:-}" ] && [ -n "${PUBLISH_LOCK_ID:-}" ]; then
+  read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-lock.json \
+    "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record/${RELEASE_RECORD_ID}?fieldKeyType=dbFieldName" \
+    -H "Authorization: Bearer ${TEABLE_API_TOKEN}")
+
+  if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
+    echo "Failed to read Release publishing metadata: HTTP ${read_http_code}"
+    cat /tmp/release-lock.json
+    exit 1
+  fi
+
+  release_metadata=$(jq -cer '.fields.Publishing_Metadata | fromjson' /tmp/release-lock.json) || {
+    echo "Release publishing metadata is missing or invalid"
+    exit 1
+  }
+  current_lock_id=$(jq -r '.lockId // empty' <<<"$release_metadata")
+  current_state=$(jq -r '.state // empty' <<<"$release_metadata")
+  target_is_locked=$(jq -r --arg target "$target" '(.targets // []) | index($target) != null' <<<"$release_metadata")
+  already_completed=$(jq -r --arg target "$target" \
+    '(((.launchedTargets // []) + (.completedTargets // [])) | unique) | index($target) != null' \
+    <<<"$release_metadata")
+
+  if [ "$already_completed" = "true" ]; then
+    echo "${REGION} is already recorded for publishing lock ${PUBLISH_LOCK_ID}"
+    exit 0
+  fi
+
+  if [ "$current_state" != "launching" ] || [ "$current_lock_id" != "$PUBLISH_LOCK_ID" ] || [ "$target_is_locked" != "true" ]; then
+    echo "Release publishing lock no longer authorizes ${REGION}"
+    exit 1
+  fi
+fi
+
+current_time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+related_release_ids_json=$(printf '%s' "${RELATED_RELEASE_RECORD_IDS:-}" | \
+  jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
+
+payload=$(jq -n \
+  --arg date "$current_time" \
+  --arg region "$REGION" \
+  --arg trigger "${TRIGGER:-Manual}" \
+  --arg imageTag "$IMAGE_TAG" \
+  --arg snapshot "${RELEASE_CREATED_TIME:-}" \
+  --arg refinedChangelog "${REFINED_CHANGELOG:-}" \
+  --arg refinedChangelogZh "${REFINED_CHANGELOG_ZH:-}" \
+  --argjson relatedReleaseIds "$related_release_ids_json" \
+  '{
+    "fieldKeyType": "dbFieldName",
+    "typecast": true,
+    "records": [
+      {
+        "fields": {
+          "date": $date,
+          "region": $region,
+          "trigger": $trigger,
+          "EE_Lanched_Release": $imageTag,
+          "Deploy_snapshot_time": (if $snapshot != "" then $snapshot else null end),
+          "Related_Releases": (if ($relatedReleaseIds | length) > 0 then $relatedReleaseIds else null end),
+          "Refined_Changelog": (if $refinedChangelog != "" then $refinedChangelog else null end),
+          "Refined_Changelog_Zhong_Wen": (if $refinedChangelogZh != "" then $refinedChangelogZh else null end)
+        }
+      }
+    ]
+  }')
+
+create_http_code=$(curl -sS -w "%{http_code}" -o /tmp/launch-create.json -X POST \
+  "${TEABLE_API_BASE}/table/${LAUNCHES_TABLE_ID}/record" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d "$payload")
+
+if [ "$create_http_code" -lt 200 ] || [ "$create_http_code" -ge 300 ]; then
+  echo "Failed to create ${REGION} Launch: HTTP ${create_http_code}"
+  cat /tmp/launch-create.json
+  exit 1
+fi
+
+launch_record_id=$(jq -r '.records[0].id // empty' /tmp/launch-create.json)
+echo "Created ${REGION} Launch ${launch_record_id}"

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -467,12 +467,21 @@ jobs:
   notify:
     name: Record Deployment in Teable
     needs: [prepare, deploy-sandbox, deploy-app, promote-latest, sync-aliyun]
-    if: always()
+    if: >-
+      needs.deploy-sandbox.result == 'success' &&
+      needs.deploy-app.result == 'success' &&
+      needs.promote-latest.result == 'success' &&
+      needs.sync-aliyun.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Record deployment in Teable
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create teable.ai Launch
         env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          REGION: teable.ai
           IMAGE_TAG: ${{ inputs.image_tag }}
           TRIGGER: ${{ inputs.trigger || github.actor }}
           RELEASE_CREATED_TIME: ${{ inputs.release_created_time }}
@@ -480,75 +489,28 @@ jobs:
           RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
           REFINED_CHANGELOG: ${{ inputs.refined_changelog }}
           REFINED_CHANGELOG_ZH: ${{ inputs.refined_changelog_zh }}
-        run: |
-          current_time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-          related_release_ids_json=$(printf '%s' "$RELATED_RELEASE_RECORD_IDS" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+        run: bash .github/scripts/record-teable-launch.sh
 
-          # Build JSON payload using jq to properly escape special characters
-          payload=$(jq -n \
-            --arg date "$current_time" \
-            --arg region "teable.ai" \
-            --arg trigger "$TRIGGER" \
-            --arg snapshot "$RELEASE_CREATED_TIME" \
-            --arg refinedChangelog "$REFINED_CHANGELOG" \
-            --arg refinedChangelogZh "$REFINED_CHANGELOG_ZH" \
-            --argjson relatedReleaseIds "$related_release_ids_json" \
-            '{
-              "fieldKeyType": "dbFieldName",
-              "typecast": true,
-              "records": [
-                {
-                  "fields": {
-                    "date": $date,
-                    "region": $region,
-                    "trigger": $trigger,
-                    "Deploy_snapshot_time": (if $snapshot != "" then $snapshot else null end),
-                    "Related_Releases": (if ($relatedReleaseIds | length) > 0 then $relatedReleaseIds else null end),
-                    "Refined_Changelog": (if $refinedChangelog != "" then $refinedChangelog else null end),
-                    "Refined_Changelog_Zhong_Wen": (if $refinedChangelogZh != "" then $refinedChangelogZh else null end)
-                  }
-                }
-              ]
-            }')
+  finalize-release:
+    name: Finalize Release publishing progress
+    needs: notify
+    if: >-
+      needs.notify.result == 'success' &&
+      inputs.release_record_id != '' &&
+      inputs.publish_lock_id != ''
+    runs-on: ubuntu-latest
+    concurrency:
+      group: finalize-teable-release-${{ inputs.release_record_id }}
 
-          # Make the API call and capture both response and HTTP status code
-          http_code=$(curl -s -w "%{http_code}" -o /tmp/response.json -X POST 'https://app.teable.ai/api/table/tblmGAFOHrGcy66PaUp/record' \
-            -H 'Authorization: Bearer ${{ secrets.TEABLE_API_TOKEN }}' \
-            -H 'Content-Type: application/json' \
-            -d "$payload")
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-          response=$(cat /tmp/response.json)
-          echo "Response: $response"
-          echo "HTTP Status Code: $http_code"
-
-          # Check if request was successful
-          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
-            record_id=$(echo "$response" | jq -r '.records[0].id')
-            echo "Created deployment record with ID: ${record_id}"
-
-            if [ -n "$RELEASE_RECORD_ID" ]; then
-              update_payload=$(jq -n \
-                '{
-                  "fieldKeyType": "dbFieldName",
-                  "typecast": true,
-                  "record": {
-                    "fields": {
-                      "status": "Launched",
-                      "Publishing_Metadata": null
-                    }
-                  }
-                }')
-
-              update_http_code=$(curl -s -w "%{http_code}" -o /tmp/release-update.json -X PATCH \
-                "https://app.teable.ai/api/table/tblAhVLOxNtvkaF1ii5/record/${RELEASE_RECORD_ID}" \
-                -H 'Authorization: Bearer ${{ secrets.TEABLE_API_TOKEN }}' \
-                -H 'Content-Type: application/json' \
-                -d "$update_payload")
-
-              echo "Updated release record ${RELEASE_RECORD_ID} to Launched: HTTP ${update_http_code}"
-            fi
-          else
-            echo "Error: API request failed with status code $http_code"
-            echo "Response: $response"
-            exit 1
-          fi
+      - name: Record teable.ai completion
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+        run: bash .github/scripts/finalize-teable-release.sh

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -11,23 +11,23 @@ on:
         required: false
         default: 'Manual'
       release_created_time:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Creation time of the Release record that triggered this deploy'
         required: false
         default: ''
       release_record_id:
-        description: 'Cloud Release record ID used to clear a CN-only publishing lock'
+        description: 'Cloud Release record ID used to track publishing progress'
         required: false
         default: ''
       related_release_record_ids:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Comma-separated Release record IDs to link on the Launch'
         required: false
         default: ''
       refined_changelog:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Reviewed English changelog to store on the Launch'
         required: false
         default: ''
       refined_changelog_zh:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Reviewed Chinese changelog to store on the Launch'
         required: false
         default: ''
       publish_mode:
@@ -50,27 +50,27 @@ on:
         type: string
         default: 'Automation'
       release_created_time:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Creation time of the Release record that triggered this deploy'
         required: false
         type: string
         default: ''
       release_record_id:
-        description: 'Cloud Release record ID used to clear a CN-only publishing lock'
+        description: 'Cloud Release record ID used to track publishing progress'
         required: false
         type: string
         default: ''
       related_release_record_ids:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Comma-separated Release record IDs to link on the Launch'
         required: false
         type: string
         default: ''
       refined_changelog:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Reviewed English changelog to store on the Launch'
         required: false
         type: string
         default: ''
       refined_changelog_zh:
-        description: 'Deprecated compatibility input; teable.cn does not create Launch records'
+        description: 'Reviewed Chinese changelog to store on the Launch'
         required: false
         type: string
         default: ''
@@ -302,51 +302,49 @@ jobs:
         with:
           args: rollout status deployment/teable-cloud
 
-      - name: Release CN-only publishing lock
-        if: inputs.publish_mode == 'cn' && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+
+  notify:
+    name: Record teable.cn Launch
+    needs: deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create teable.cn Launch
         env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          REGION: teable.cn
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          TRIGGER: ${{ inputs.trigger || github.actor }}
+          RELEASE_CREATED_TIME: ${{ inputs.release_created_time }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
+          REFINED_CHANGELOG: ${{ inputs.refined_changelog }}
+          REFINED_CHANGELOG_ZH: ${{ inputs.refined_changelog_zh }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+        run: bash .github/scripts/record-teable-launch.sh
+
+  finalize-release:
+    name: Finalize Release publishing progress
+    needs: notify
+    if: >-
+      needs.notify.result == 'success' &&
+      inputs.release_record_id != '' &&
+      inputs.publish_lock_id != ''
+    runs-on: ubuntu-latest
+    concurrency:
+      group: finalize-teable-release-${{ inputs.release_record_id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Record teable.cn completion
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
           RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
-        run: |
-          set -euo pipefail
-
-          read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-lock.json \
-            "https://app.teable.ai/api/table/tblAhVLOxNtvkaF1ii5/record/${RELEASE_RECORD_ID}?fieldKeyType=dbFieldName" \
-            -H 'Authorization: Bearer ${{ secrets.TEABLE_API_TOKEN }}')
-
-          if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
-            echo "Failed to read release lock: HTTP ${read_http_code}"
-            cat /tmp/release-lock.json
-            exit 1
-          fi
-
-          current_lock_id=$(jq -r '.fields.Publishing_Metadata // empty | fromjson? | .lockId // empty' /tmp/release-lock.json)
-          if [ "$current_lock_id" != "$PUBLISH_LOCK_ID" ]; then
-            echo "Publishing lock changed; skip clearing lock ${PUBLISH_LOCK_ID}"
-            exit 0
-          fi
-
-          update_payload=$(jq -n '{
-            "fieldKeyType": "dbFieldName",
-            "typecast": true,
-            "record": {
-              "fields": {
-                "status": "Released",
-                "Publishing_Metadata": null
-              }
-            }
-          }')
-
-          update_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-unlock.json -X PATCH \
-            "https://app.teable.ai/api/table/tblAhVLOxNtvkaF1ii5/record/${RELEASE_RECORD_ID}" \
-            -H 'Authorization: Bearer ${{ secrets.TEABLE_API_TOKEN }}' \
-            -H 'Content-Type: application/json' \
-            -d "$update_payload")
-
-          if [ "$update_http_code" -lt 200 ] || [ "$update_http_code" -ge 300 ]; then
-            echo "Failed to clear CN-only publishing lock: HTTP ${update_http_code}"
-            cat /tmp/release-unlock.json
-            exit 1
-          fi
-
-          echo "Cleared CN-only publishing lock ${PUBLISH_LOCK_ID}"
+          TARGET: cn
+        run: bash .github/scripts/finalize-teable-release.sh


### PR DESCRIPTION
## Summary
- create one Launch record for each successful teable.ai or teable.cn deployment
- keep Launch creation parallel so the first completed environment is recorded immediately
- serialize only the short Release progress finalization to avoid lost metadata updates
- keep a Release publishable until both environments have completed

## Validation
- bash syntax checks for both shared scripts
- YAML parse checks via Prettier
- simulated AI-first, CN-first, single-target, and second-target state transitions