### PR TITLE
ci: preheat CN sandbox agent on the sealos launch path

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -433,6 +433,7 @@ jobs:
     uses: ./.github/workflows/preheat-sandbox-agent-cloud.yaml
     with:
       image_tag: ${{ inputs.image_tag }}
+      best_effort: true
     secrets: inherit
 
   # With the release stamped and deployed, the accumulated cloud staging

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -190,6 +190,7 @@ jobs:
     with:
       image_tag: ${{ inputs.image_tag }}
       targets: cn
+      best_effort: true
     secrets: inherit
 
   deploy:

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -105,6 +105,9 @@ on:
         required: false
       ALI_DOCKER_PASSWORD:
         required: false
+      # Used by the preheat-sandbox-agent job — same contract as above.
+      INFRA_TEABLE_CN_PREHEAT_TOKEN:
+        required: false
 
 jobs:
   # teable.cn deploys official release.<id> tags from Aliyun, but Aliyun
@@ -175,6 +178,19 @@ jobs:
               "${DST_REGISTRY}/${image}:${TAG}" \
               "$DST_CREDS"
           done
+
+  # Preheat CN sandbox-agent nodes as soon as the agent tag lands on Aliyun,
+  # so a CN-first launch doesn't wait for the AI launch's both-cloud preheat.
+  # Best-effort: not part of the notify gating — a preheat miss only costs
+  # first-spawn latency.
+  preheat-sandbox-agent:
+    needs: ensure-aliyun
+    if: needs.ensure-aliyun.result == 'success'
+    uses: ./.github/workflows/preheat-sandbox-agent-cloud.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      targets: cn
+    secrets: inherit
 
   deploy:
     name: Deploy to Sealos

--- a/.github/workflows/preheat-sandbox-agent-cloud.yaml
+++ b/.github/workflows/preheat-sandbox-agent-cloud.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         default: 'ai,cn'
         type: string
+      best_effort:
+        description: 'Warn instead of fail when a preheat call errors'
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       image_tag:
@@ -21,9 +26,17 @@ on:
         required: false
         default: 'ai,cn'
         type: string
+      # Launch workflows pass true: a preheat miss only costs first-spawn
+      # latency, and reusable-call jobs cannot use continue-on-error, so the
+      # downgrade to a warning has to happen here.
+      best_effort:
+        required: false
+        default: false
+        type: boolean
     # required: false so a single-target caller (e.g. manual-sealos-deploy
     # preheating cn only) doesn't have to provide the other cloud's token;
-    # a selected target with a missing token still fails its step loudly.
+    # a selected target with a missing token still fails its step loudly
+    # (or warns, under best_effort).
     secrets:
       INFRA_TEABLE_AI_PREHEAT_TOKEN:
         required: false
@@ -40,6 +53,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           PREHEAT_TOKEN: ${{ secrets.INFRA_TEABLE_AI_PREHEAT_TOKEN }}
+          BEST_EFFORT: ${{ inputs.best_effort }}
         run: |
           set -euo pipefail
 
@@ -49,16 +63,20 @@ jobs:
             -X POST 'https://infra.teable.ai/api/image-preheats' \
             -H "Authorization: Bearer ${PREHEAT_TOKEN}" \
             -H 'Content-Type: application/json' \
-            --data "$payload")"
+            --data "$payload")" || http_code="000"
 
-          response="$(cat /tmp/preheat-ai-response.json)"
+          response="$(cat /tmp/preheat-ai-response.json 2>/dev/null || echo '')"
           echo "Preheat image: ${image}"
           echo "HTTP status: ${http_code}"
           echo "Response: ${response}"
 
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-            echo "::error::teable.ai image preheat failed with HTTP ${http_code}"
-            exit 1
+            if [ "$BEST_EFFORT" = "true" ]; then
+              echo "::warning::teable.ai image preheat failed with HTTP ${http_code} (best-effort, not failing the run)"
+            else
+              echo "::error::teable.ai image preheat failed with HTTP ${http_code}"
+              exit 1
+            fi
           fi
 
       - name: Preheat teable.cn sandbox agent image
@@ -66,6 +84,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           PREHEAT_TOKEN: ${{ secrets.INFRA_TEABLE_CN_PREHEAT_TOKEN }}
+          BEST_EFFORT: ${{ inputs.best_effort }}
         run: |
           set -euo pipefail
 
@@ -75,14 +94,18 @@ jobs:
             -X POST 'https://infra.teable.cn/api/image-preheats' \
             -H "Authorization: Bearer ${PREHEAT_TOKEN}" \
             -H 'Content-Type: application/json' \
-            --data "$payload")"
+            --data "$payload")" || http_code="000"
 
-          response="$(cat /tmp/preheat-cn-response.json)"
+          response="$(cat /tmp/preheat-cn-response.json 2>/dev/null || echo '')"
           echo "Preheat image: ${image}"
           echo "HTTP status: ${http_code}"
           echo "Response: ${response}"
 
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-            echo "::error::teable.cn image preheat failed with HTTP ${http_code}"
-            exit 1
+            if [ "$BEST_EFFORT" = "true" ]; then
+              echo "::warning::teable.cn image preheat failed with HTTP ${http_code} (best-effort, not failing the run)"
+            else
+              echo "::error::teable.cn image preheat failed with HTTP ${http_code}"
+              exit 1
+            fi
           fi

--- a/.github/workflows/preheat-sandbox-agent-cloud.yaml
+++ b/.github/workflows/preheat-sandbox-agent-cloud.yaml
@@ -7,16 +7,28 @@ on:
         description: 'Release image tag (e.g., release.2026-06-11T01-53-35Z.1879)'
         required: true
         type: string
+      targets:
+        description: 'Comma-separated clouds to preheat: ai, cn'
+        required: false
+        default: 'ai,cn'
+        type: string
   workflow_call:
     inputs:
       image_tag:
         required: true
         type: string
+      targets:
+        required: false
+        default: 'ai,cn'
+        type: string
+    # required: false so a single-target caller (e.g. manual-sealos-deploy
+    # preheating cn only) doesn't have to provide the other cloud's token;
+    # a selected target with a missing token still fails its step loudly.
     secrets:
       INFRA_TEABLE_AI_PREHEAT_TOKEN:
-        required: true
+        required: false
       INFRA_TEABLE_CN_PREHEAT_TOKEN:
-        required: true
+        required: false
 
 jobs:
   preheat:
@@ -24,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Preheat teable.ai sandbox agent image
+        if: contains(inputs.targets, 'ai')
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           PREHEAT_TOKEN: ${{ secrets.INFRA_TEABLE_AI_PREHEAT_TOKEN }}
@@ -49,6 +62,7 @@ jobs:
           fi
 
       - name: Preheat teable.cn sandbox agent image
+        if: contains(inputs.targets, 'cn')
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           PREHEAT_TOKEN: ${{ secrets.INFRA_TEABLE_CN_PREHEAT_TOKEN }}


### PR DESCRIPTION
## Background

The release-tag-is-official rework moved the Aliyun sync, durable tags, and the agent preheat to launch time. One gap remained: **a CN-first launch got no agent preheat** — the preheat only ran inside manual-ecs-deploy (both clouds at once), while manual-sealos-deploy's ensure-aliyun copies images but never preheats, so CN nodes stayed cold until the AI launch ran.

## Changes

- **preheat-sandbox-agent-cloud.yaml**
  - New `targets` input (default `ai,cn`; existing caller behavior unchanged); each preheat step runs only when its cloud is selected.
  - New `best_effort` input (default `false` keeps manual dispatch strict): a preheat error becomes a warning instead of failing the run. Reusable-call jobs can't use `continue-on-error`, so the downgrade lives in the called workflow. Transport-level curl failures are guarded onto the same path.
  - Preheat token secrets relax to `required: false` so a single-target caller doesn't have to carry the other cloud's token; a selected target with a missing token still surfaces loudly.
- **manual-sealos-deploy.yaml**: after `ensure-aliyun`, call the preheat workflow with `targets: cn` and `best_effort: true`, outside the notify/finalize gating — same contract as the ecs-deploy preheat: a miss only costs first-spawn latency. The workflow_call secrets contract gains `INFRA_TEABLE_CN_PREHEAT_TOKEN` (required: false, same convention as PACKAGES_KEY).
- **manual-ecs-deploy.yml**: pass `best_effort: true` so its preheat matches its stated best-effort comment instead of failing the launch run.

## Verification

- All three files parse cleanly with js-yaml.
- manual-ecs-deploy passes no `targets`, so the default `ai,cn` preserves current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)