### PR TITLE
ci: unify build status — both editions share one outcome, no partial success

### DIFF
--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -4,11 +4,15 @@ name: Build teable (unified)
 # args (edition flag, Sentry sourcemaps, CDN asset prefix), and since the
 # deps-cache/agent-fast-lane work the EE build is no slower than cloud — so
 # a single trigger builds everything, with one release id, shared deps cache,
-# and the agent built exactly once. The editions keep INDEPENDENT release
-# statuses: separate build matrices, separate sync chains, separate tracking
-# records — an EE-only leg failure does not block the cloud release or vice
-# versa. The cloud lane's old cross-workflow verify-agent poll is gone: cloud
-# syncs simply `needs: merge-agent-manifest` in-run.
+# and the agent built exactly once. The editions share ONE release status:
+# separate build matrices and sync chains, but a single outcome written to
+# both tracking records — a release id is Released only when BOTH lanes
+# fully published. Partial success is deliberately not a recordable state:
+# release.2313 had its cloud lane finish and report success while the EE
+# arm64 leg was concurrency-cancelled minutes later, so the release button
+# offered an id whose EE artifacts never existed and promotion died on a
+# missing beta tag. The cloud lane's old cross-workflow verify-agent poll
+# is gone: cloud syncs simply `needs: merge-agent-manifest` in-run.
 #
 # mode=rehearsal (validation runs): builds everything and pushes ONLY the
 # pinned beta-* tag — no beta/latest movement, no dockerhub/ECR sync, no
@@ -810,15 +814,24 @@ jobs:
               "docker://${ECR_REGISTRY}/${image}:${BETA_TAG}"
           done
 
-  # ── Per-edition statuses (independent releases from one run) ───────────
-
-  determine-status-ee:
+  # ── Unified status (one build, one outcome — no partial success) ───────
+  #
+  # Cloud and EE are one build task that only differs in upload targets, so
+  # they succeed or fail TOGETHER: both tracking records get the same final
+  # status, and it is Released only when every lane fully published. On
+  # routine builds the lanes finish within ~1-2 min of each other; the one
+  # wide gap is an agent-base rebuild (~19 min of EE lag), which is exactly
+  # the window where a concurrency cancel used to leave the cloud record
+  # Released while the EE beta tag never landed (release.2313).
+  determine-status:
     needs:
       [
         prepare-release,
+        build-push-cloud,
         build-push-ee,
         merge-manifests-ee,
         merge-agent-manifest,
+        sync-ecr,
         sync-dockerhub,
       ]
     if: always()
@@ -826,7 +839,7 @@ jobs:
     outputs:
       status: ${{ steps.status.outputs.status }}
     steps:
-      - name: Determine final EE status
+      - name: Determine final unified status
         id: status
         run: |
           # sync-dockerhub legitimately skips on non-develop builds (the
@@ -834,63 +847,37 @@ jobs:
           DOCKERHUB="${{ needs.sync-dockerhub.result }}"
           if [ "${{ needs.prepare-release.outputs.mode }}" != "release" ]; then
             echo "status=Rehearsal" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "$DOCKERHUB" == "cancelled" ]; then
+          elif [ "${{ needs.build-push-cloud.result }}" == "cancelled" ] || [ "${{ needs.build-push-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ] || [ "$DOCKERHUB" == "cancelled" ]; then
             echo "status=Cancelled" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-ee.result }}" == "success" ] && [ "${{ needs.merge-manifests-ee.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && { [ "$DOCKERHUB" == "success" ] || [ "$DOCKERHUB" == "skipped" ]; }; then
-            echo "status=Released" >> $GITHUB_OUTPUT
-          else
-            echo "status=Fail" >> $GITHUB_OUTPUT
-          fi
-
-  determine-status-cloud:
-    needs:
-      [
-        prepare-release,
-        build-push-cloud,
-        merge-agent-manifest,
-        sync-ecr,
-      ]
-    if: always()
-    runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.status.outputs.status }}
-    steps:
-      - name: Determine final cloud status
-        id: status
-        run: |
-          if [ "${{ needs.prepare-release.outputs.mode }}" != "release" ]; then
-            echo "status=Rehearsal" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-cloud.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ]; then
-            echo "status=Cancelled" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-cloud.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ]; then
+          elif [ "${{ needs.build-push-cloud.result }}" == "success" ] && [ "${{ needs.build-push-ee.result }}" == "success" ] && [ "${{ needs.merge-manifests-ee.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ] && { [ "$DOCKERHUB" == "success" ] || [ "$DOCKERHUB" == "skipped" ]; }; then
             echo "status=Released" >> $GITHUB_OUTPUT
           else
             echo "status=Fail" >> $GITHUB_OUTPUT
           fi
 
   track-complete-ee:
-    needs: [prepare-release, track-start-ee, determine-status-ee]
+    needs: [prepare-release, track-start-ee, determine-status]
     if: always() && needs.prepare-release.outputs.mode == 'release' && needs.track-start-ee.result == 'success'
     uses: ./.github/workflows/track-build-teable.yaml
     with:
       action: update
       edition: ee
       record_id: ${{ needs.track-start-ee.outputs.record_id }}
-      status: ${{ needs.determine-status-ee.outputs.status }}
+      status: ${{ needs.determine-status.outputs.status }}
       start_time: ${{ needs.track-start-ee.outputs.start_time }}
     secrets:
       TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
       PACKAGES_KEY: ${{ secrets.PACKAGES_KEY }}
 
   track-complete-cloud:
-    needs: [prepare-release, track-start-cloud, determine-status-cloud]
+    needs: [prepare-release, track-start-cloud, determine-status]
     if: always() && needs.prepare-release.outputs.mode == 'release' && needs.track-start-cloud.result == 'success'
     uses: ./.github/workflows/track-build-teable.yaml
     with:
       action: update
       edition: cloud
       record_id: ${{ needs.track-start-cloud.outputs.record_id }}
-      status: ${{ needs.determine-status-cloud.outputs.status }}
+      status: ${{ needs.determine-status.outputs.status }}
       start_time: ${{ needs.track-start-cloud.outputs.start_time }}
     secrets:
       TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}


### PR DESCRIPTION
## Why

`release.2026-07-21T08-19-54Z.2313` exposed a gap in the per-edition status model:

1. The cloud lane finished completely (~16:45 CST): images pushed, ECR synced, cloud tracking record marked **Released**.
2. One minute later a develop merge triggered the next unified build, and `cancel-in-progress` killed the still-running EE arm64 leg — `merge-manifests-ee` never ran, so `teable-staging:beta-…2313` was never pushed.
3. The Releases table showed 2313 as publishable (the gate only saw the cloud record), the releaser pressed DeployAI, and promotion died 20 minutes later on `beta-…2313: not found`.

The lanes are one build task that differs only in upload targets, so treating them as independently successful invites exactly this trap. Per review decision: **no partial success is recorded**.

## What

- Merge `determine-status-ee` / `determine-status-cloud` into a single `determine-status` that `needs` every lane of both editions (`build-push-cloud`, `build-push-ee`, `merge-manifests-ee`, `merge-agent-manifest`, `sync-ecr`, `sync-dockerhub`).
- Both `track-complete-*` jobs write that single status to their records — cloud and EE records always agree.
- Status semantics unchanged (`Released` / `Cancelled` / `Fail` / `Rehearsal`); `sync-dockerhub` skipped still counts as success (non-develop builds don't float the beta channel).
- Header comment updated: the "editions keep INDEPENDENT release statuses" design statement no longer holds.

## Cost

Routine builds: ~1-2 min (lanes finish nearly together since the deps-cache/agent-fast-lane work — measured on build no.47: cloud ~15 min, EE ~16 min). The only wide gap is an agent-base rebuild (~19 min EE lag), which is precisely the window that produced 2313 — that window is now covered instead of racing the release button.

An EE-only infra flake now blocks the cloud status too; recovery is GitHub's **Re-run failed jobs**, which re-runs the failed leg plus the status/tracking jobs downstream of it.

## Verified

- `determine-status`-style `if: always()` jobs demonstrably run even when the run is concurrency-cancelled (build no.46's `track-complete-ee` executed at 16:52, one minute after the 16:51 cancel), so cancelled runs will mark both records `Cancelled` rather than leaving `Building` forever.
- YAML parses; no other workflow references the old job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)