### PR TITLE
ci(preview): converge instance-init image on cloud preview updates

### DIFF
--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -271,14 +271,18 @@ jobs:
         with:
           args: annotate deployment/teable-${{ env.INSTANCE_NAME }}-sandbox originImageName="${{ env.SANDBOX_IMAGE }}" --overwrite
 
-      - name: Update main deployment image (container + init container)
+      - name: Update main deployment image (container + init containers)
         if: steps.check_deploy.outcome == 'success'
         uses: actions-hub/kubectl@master
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
           MAIN_IMAGE: registry.cn-shenzhen.aliyuncs.com/teable/teable-cloud-preview:${{ needs.build-push.outputs.main_commit_sha }}
         with:
-          args: set image deployment/teable-${{ env.INSTANCE_NAME }} teable-${{ env.INSTANCE_NAME }}=${{ env.MAIN_IMAGE }} db-migrate=${{ env.MAIN_IMAGE }}
+          # instance-init included: since teable-ee#2657 it runs the app
+          # image too, and existing envs must converge off the old docker.io
+          # psql image (unreachable from the hzh cluster) on their next
+          # update — the update path never re-renders the template.
+          args: set image deployment/teable-${{ env.INSTANCE_NAME }} teable-${{ env.INSTANCE_NAME }}=${{ env.MAIN_IMAGE }} db-migrate=${{ env.MAIN_IMAGE }} instance-init=${{ env.MAIN_IMAGE }}
 
       - name: Update main deployment annotations
         if: steps.check_deploy.outcome == 'success'


### PR DESCRIPTION
Companion to teableio/teable-ee#2657.

The cloud preview **update** path never re-renders the template — for an existing env it only runs `kubectl set image` on the main container and `db-migrate`. Verified live on pr-cloud-2657: after the template fix merged into the branch, an update deploy still produced ReplicaSets carrying `instance-init: senzing/postgresql-client:2.2.4` (dead from the hzh cluster — 100x `Init:ImagePullBackOff` i/o timeouts to docker.io), because that init container's image is never touched.

One-line fix: include `instance-init=${MAIN_IMAGE}` in the set-image call so existing envs converge to the reachable Aliyun app image on their next update, and freshly-created envs keep all three images on the same tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)