### PR TITLE
ci(track): typecast status writes and fail loudly on rejected updates

### DIFF
--- a/.github/workflows/track-build-teable.yaml
+++ b/.github/workflows/track-build-teable.yaml
@@ -137,6 +137,7 @@ jobs:
             --arg runs "$RUNS" \
             '{
               "fieldKeyType": "dbFieldName",
+              "typecast": true,
               "records": [
                 {
                   "fields": {
@@ -168,19 +169,20 @@ jobs:
           echo "Response: $response"
           echo "HTTP Status Code: $http_code"
           
-          # Check if request was successful
+          # A tracking record that silently fails to land leaves the release
+          # invisible in the table — fail the job so it shows up red.
           if [ "$curl_exit_code" -ne 0 ]; then
-            echo "::warning title=Teable tracking create failed::curl exited with code $curl_exit_code"
-            echo "record_id=" >> $GITHUB_OUTPUT
+            echo "::error title=Teable tracking create failed::curl exited with code $curl_exit_code"
+            exit 1
           elif [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
             # Extract record ID from response
             record_id=$(echo "$response" | jq -r '.records[0].id')
             echo "record_id=${record_id}" >> $GITHUB_OUTPUT
             echo "Created record with ID: ${record_id}"
           else
-            echo "::warning title=Teable tracking create failed::API request failed with status code $http_code"
+            echo "::error title=Teable tracking create failed::API request failed with status code $http_code"
             echo "Response: $response"
-            echo "record_id=" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
       - name: Calculate duration
@@ -215,6 +217,7 @@ jobs:
             --argjson duration "$DURATION" \
             '{
               "fieldKeyType": "dbFieldName",
+              "typecast": true,
               "record": {
                 "fields": {
                   "status": $status,
@@ -238,15 +241,18 @@ jobs:
           echo "Response: $response"
           echo "HTTP Status Code: $http_code"
           
-          # Check if request was successful
+          # A final status that silently fails to land strands the record in
+          # "Building" and suppresses the build-notification automation (this
+          # exact failure shipped "Cancelled" for three days while the Status
+          # field had no such option) — fail the job so it shows up red.
           if [ "$curl_exit_code" -ne 0 ]; then
-            echo "::warning title=Teable tracking update failed::curl exited with code $curl_exit_code"
-            echo "record_id=$RECORD_ID" >> $GITHUB_OUTPUT
+            echo "::error title=Teable tracking update failed::curl exited with code $curl_exit_code"
+            exit 1
           elif [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
             echo "record_id=$RECORD_ID" >> $GITHUB_OUTPUT
             echo "Updated record $RECORD_ID with status: $STATUS"
           else
-            echo "::warning title=Teable tracking update failed::API request failed with status code $http_code"
+            echo "::error title=Teable tracking update failed::API request failed with status code $http_code"
             echo "Response: $response"
-            echo "record_id=$RECORD_ID" >> $GITHUB_OUTPUT
+            exit 1
           fi


### PR DESCRIPTION
## Why

Screenshot symptom: superseded builds (2313-ee, 2315, 2316) stuck at **Building** forever.

Verified chain from run no.48/49 logs:
1. `determine-status` correctly emitted `status: Cancelled` for concurrency-cancelled builds (string introduced by the channel rework on 07-18);
2. the Releases table's Status singleSelect only had `Building | Released | Launching | Fail | Launched` — the PATCH returned **400 Invalid option**;
3. the track step logged a `::warning` and exited 0 → record stranded at Building;
4. the 研发群 build-notification automation triggers on Status changes and already has a "构建取消" branch — it simply never fired because the status never landed.

## What

- `typecast: true` on both the create POST and the update PATCH — Teable auto-creates missing select options, so a status string can never be silently rejected again.
- Non-2xx / curl failures now `exit 1` — a tracking write that doesn't land turns the job red instead of whispering a warning (this exact failure shipped for three days unseen).

## Already done out-of-band

- `Cancelled` option now exists on the Status field (auto-created via a typecast PATCH).
- Stuck records backfilled to Cancelled: 2313-ee, 2315 (both editions), 2316 (both editions) — each backfill fired the 研发群 automation, confirming the notification path works end-to-end with the new status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)