### PR TITLE
支持按 Launch 回滚 Cloud 与 EE latest

### DIFF
--- a/.github/scripts/complete-teable-rollback.sh
+++ b/.github/scripts/complete-teable-rollback.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEABLE_API_TOKEN:?TEABLE_API_TOKEN is required}"
+: "${SOURCE_LAUNCH_ID:?SOURCE_LAUNCH_ID is required}"
+: "${ROLLBACK_LOCK_ID:?ROLLBACK_LOCK_ID is required}"
+: "${REGION:?REGION is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+TEABLE_API_BASE="https://app.teable.ai/api"
+LAUNCHES_TABLE_ID="tblmGAFOHrGcy66PaUp"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+bash "${SCRIPT_DIR}/validate-teable-rollback.sh"
+
+export OPERATION_TYPE="Rollback"
+export RELEASE_CREATED_TIME=$(jq -r '.fields.Deploy_snapshot_time // empty' /tmp/rollback-source-launch.json)
+export RELATED_RELEASE_RECORD_IDS=$(jq -r \
+  '(.fields.Related_Releases // []) | map(if type == "object" then .id else . end) | map(select(type == "string" and length > 0)) | join(",")' \
+  /tmp/rollback-source-launch.json)
+export REFINED_CHANGELOG=$(jq -r '.fields.Refined_Changelog // empty' /tmp/rollback-source-launch.json)
+export REFINED_CHANGELOG_ZH=$(jq -r '.fields.Refined_Changelog_Zhong_Wen // empty' /tmp/rollback-source-launch.json)
+unset PUBLISH_LOCK_ID
+unset RELEASE_RECORD_ID
+bash "${SCRIPT_DIR}/record-teable-launch.sh"
+
+completed_at=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+update_payload=$(jq -n \
+  --arg status "Succeeded" \
+  '{
+    "fieldKeyType": "dbFieldName",
+    "typecast": true,
+    "record": {
+      "fields": {
+        "Rollback_Status": $status,
+        "Rollback_Metadata": null
+      }
+    }
+  }')
+
+update_http_code=$(curl -sS -w "%{http_code}" -o /tmp/rollback-source-update.json -X PATCH \
+  "${TEABLE_API_BASE}/table/${LAUNCHES_TABLE_ID}/record/${SOURCE_LAUNCH_ID}" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d "$update_payload")
+
+if [ "$update_http_code" -lt 200 ] || [ "$update_http_code" -ge 300 ]; then
+  echo "Rollback deployed but source Launch status update failed: HTTP ${update_http_code}"
+  cat /tmp/rollback-source-update.json
+  exit 1
+fi
+
+echo "Completed ${REGION} + EE latest rollback to ${IMAGE_TAG} at ${completed_at}"

--- a/.github/scripts/mark-teable-rollback-failed.sh
+++ b/.github/scripts/mark-teable-rollback-failed.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEABLE_API_TOKEN:?TEABLE_API_TOKEN is required}"
+: "${SOURCE_LAUNCH_ID:?SOURCE_LAUNCH_ID is required}"
+: "${ROLLBACK_LOCK_ID:?ROLLBACK_LOCK_ID is required}"
+
+TEABLE_API_BASE="https://app.teable.ai/api"
+LAUNCHES_TABLE_ID="tblmGAFOHrGcy66PaUp"
+
+read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/rollback-source-launch.json \
+  "${TEABLE_API_BASE}/table/${LAUNCHES_TABLE_ID}/record/${SOURCE_LAUNCH_ID}?fieldKeyType=dbFieldName" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}")
+
+if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
+  echo "Failed to read rollback source Launch: HTTP ${read_http_code}"
+  exit 1
+fi
+
+rollback_metadata=$(jq -cer '.fields.Rollback_Metadata | fromjson' /tmp/rollback-source-launch.json) || exit 0
+current_lock_id=$(jq -r '.lockId // empty' <<<"$rollback_metadata")
+if [ "$current_lock_id" != "$ROLLBACK_LOCK_ID" ]; then
+  echo "Rollback lock changed; failure status was not written"
+  exit 0
+fi
+
+failed_at=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+failed_metadata=$(jq -c \
+  --arg failedAt "$failed_at" \
+  --arg error "${ERROR_SUMMARY:-GitHub Actions rollback failed}" \
+  '.failedAt = $failedAt | .lastError = $error' \
+  <<<"$rollback_metadata")
+
+update_payload=$(jq -n \
+  --arg status "Failed" \
+  --arg metadata "$failed_metadata" \
+  '{
+    "fieldKeyType": "dbFieldName",
+    "typecast": true,
+    "record": {
+      "fields": {
+        "Rollback_Status": $status,
+        "Rollback_Metadata": $metadata
+      }
+    }
+  }')
+
+update_http_code=$(curl -sS -w "%{http_code}" -o /tmp/rollback-source-update.json -X PATCH \
+  "${TEABLE_API_BASE}/table/${LAUNCHES_TABLE_ID}/record/${SOURCE_LAUNCH_ID}" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d "$update_payload")
+
+if [ "$update_http_code" -lt 200 ] || [ "$update_http_code" -ge 300 ]; then
+  echo "Failed to mark rollback as failed: HTTP ${update_http_code}"
+  cat /tmp/rollback-source-update.json
+  exit 1
+fi
+
+echo "Marked rollback ${ROLLBACK_LOCK_ID} as failed; lock remains until expiry"

--- a/.github/scripts/record-teable-launch.sh
+++ b/.github/scripts/record-teable-launch.sh
@@ -15,6 +15,12 @@ case "$REGION" in
   *) echo "Unsupported region: $REGION"; exit 1 ;;
 esac
 
+operation_type="${OPERATION_TYPE:-Release}"
+if [ "$operation_type" != "Release" ] && [ "$operation_type" != "Rollback" ]; then
+  echo "Unsupported operation type: $operation_type"
+  exit 1
+fi
+
 if [ -n "${RELEASE_RECORD_ID:-}" ] && [ -n "${PUBLISH_LOCK_ID:-}" ]; then
   read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-lock.json \
     "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record/${RELEASE_RECORD_ID}?fieldKeyType=dbFieldName" \
@@ -60,6 +66,7 @@ payload=$(jq -n \
   --arg snapshot "${RELEASE_CREATED_TIME:-}" \
   --arg refinedChangelog "${REFINED_CHANGELOG:-}" \
   --arg refinedChangelogZh "${REFINED_CHANGELOG_ZH:-}" \
+  --arg operationType "$operation_type" \
   --argjson relatedReleaseIds "$related_release_ids_json" \
   '{
     "fieldKeyType": "dbFieldName",
@@ -74,7 +81,9 @@ payload=$(jq -n \
           "Deploy_snapshot_time": (if $snapshot != "" then $snapshot else null end),
           "Related_Releases": (if ($relatedReleaseIds | length) > 0 then $relatedReleaseIds else null end),
           "Refined_Changelog": (if $refinedChangelog != "" then $refinedChangelog else null end),
-          "Refined_Changelog_Zhong_Wen": (if $refinedChangelogZh != "" then $refinedChangelogZh else null end)
+          "Refined_Changelog_Zhong_Wen": (if $refinedChangelogZh != "" then $refinedChangelogZh else null end),
+          "Operation_Type": $operationType,
+          "Rollback_Status": (if $operationType == "Rollback" then "Succeeded" else null end)
         }
       }
     ]

--- a/.github/scripts/validate-teable-rollback.sh
+++ b/.github/scripts/validate-teable-rollback.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEABLE_API_TOKEN:?TEABLE_API_TOKEN is required}"
+: "${SOURCE_LAUNCH_ID:?SOURCE_LAUNCH_ID is required}"
+: "${ROLLBACK_LOCK_ID:?ROLLBACK_LOCK_ID is required}"
+: "${REGION:?REGION is required}"
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+
+TEABLE_API_BASE="https://app.teable.ai/api"
+LAUNCHES_TABLE_ID="tblmGAFOHrGcy66PaUp"
+
+read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/rollback-source-launch.json \
+  "${TEABLE_API_BASE}/table/${LAUNCHES_TABLE_ID}/record/${SOURCE_LAUNCH_ID}?fieldKeyType=dbFieldName" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}")
+
+if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
+  echo "Failed to read rollback source Launch: HTTP ${read_http_code}"
+  cat /tmp/rollback-source-launch.json
+  exit 1
+fi
+
+rollback_metadata=$(jq -cer '.fields.Rollback_Metadata | fromjson' /tmp/rollback-source-launch.json) || {
+  echo "Rollback metadata is missing or invalid"
+  exit 1
+}
+
+current_state=$(jq -r '.state // empty' <<<"$rollback_metadata")
+current_lock_id=$(jq -r '.lockId // empty' <<<"$rollback_metadata")
+current_region=$(jq -r '.region // empty' <<<"$rollback_metadata")
+current_image_tag=$(jq -r '.imageTag // empty' <<<"$rollback_metadata")
+expires_at=$(jq -r '.expiresAt // empty' <<<"$rollback_metadata")
+
+if [ "$current_state" != "rolling_back" ] || \
+   [ "$current_lock_id" != "$ROLLBACK_LOCK_ID" ] || \
+   [ "$current_region" != "$REGION" ] || \
+   [ "$current_image_tag" != "$IMAGE_TAG" ]; then
+  echo "Rollback lock no longer authorizes ${REGION} ${IMAGE_TAG}"
+  exit 1
+fi
+
+expires_epoch=$(date -u -d "$expires_at" +%s 2>/dev/null || echo 0)
+if [ "$expires_epoch" -le "$(date -u +%s)" ]; then
+  echo "Rollback lock expired at ${expires_at}"
+  exit 1
+fi
+
+echo "Validated rollback lock ${ROLLBACK_LOCK_ID} for ${REGION} ${IMAGE_TAG}"

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -38,6 +38,11 @@ on:
         description: 'Release Publisher lock identifier'
         required: false
         default: ''
+      record_launch:
+        description: 'Create and finalize Teable Launch records in this workflow'
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       image_tag:
@@ -84,6 +89,11 @@ on:
         required: false
         type: string
         default: ''
+      record_launch:
+        description: 'Create and finalize Teable Launch records in this workflow'
+        required: false
+        type: boolean
+        default: true
     outputs:
       start_time:
         description: 'Deployment start timestamp'
@@ -469,6 +479,7 @@ jobs:
     name: Record Deployment in Teable
     needs: [prepare, deploy-sandbox, deploy-app, promote-latest, sync-aliyun]
     if: >-
+      inputs.record_launch != false &&
       needs.deploy-sandbox.result == 'success' &&
       needs.deploy-app.result == 'success' &&
       needs.promote-latest.result == 'success' &&
@@ -497,6 +508,7 @@ jobs:
     name: Finalize Release publishing progress
     needs: notify
     if: >-
+      inputs.record_launch != false &&
       needs.notify.result == 'success' &&
       inputs.release_record_id != '' &&
       inputs.publish_lock_id != ''

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -38,6 +38,11 @@ on:
         description: 'Release Publisher lock identifier'
         required: false
         default: ''
+      record_launch:
+        description: 'Create and finalize Teable Launch records in this workflow'
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       image_tag:
@@ -84,6 +89,11 @@ on:
         required: false
         type: string
         default: ''
+      record_launch:
+        description: 'Create and finalize Teable Launch records in this workflow'
+        required: false
+        type: boolean
+        default: true
     outputs:
       start_time:
         description: 'Deployment start timestamp'
@@ -323,6 +333,7 @@ jobs:
   notify:
     name: Record teable.cn Launch
     needs: deploy
+    if: inputs.record_launch != false
     runs-on: ubuntu-latest
 
     steps:
@@ -347,6 +358,7 @@ jobs:
     name: Finalize Release publishing progress
     needs: notify
     if: >-
+      inputs.record_launch != false &&
       needs.notify.result == 'success' &&
       inputs.release_record_id != '' &&
       inputs.publish_lock_id != ''

--- a/.github/workflows/rollback-launch.yaml
+++ b/.github/workflows/rollback-launch.yaml
@@ -1,0 +1,160 @@
+name: Rollback Launch
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_launch_id:
+        description: 'Launch record selected as rollback target'
+        required: true
+        type: string
+      image_tag:
+        description: 'Immutable release.* tag used by Cloud and EE'
+        required: true
+        type: string
+      region:
+        description: 'Cloud region to roll back'
+        required: true
+        type: choice
+        options:
+          - teable.ai
+          - teable.cn
+      trigger:
+        description: 'Who triggered this rollback'
+        required: true
+        type: string
+      rollback_lock_id:
+        description: 'Release Publisher rollback lock identifier'
+        required: true
+        type: string
+
+jobs:
+  validate-lock:
+    name: Validate Launch rollback lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate rollback request
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          SOURCE_LAUNCH_ID: ${{ inputs.source_launch_id }}
+          ROLLBACK_LOCK_ID: ${{ inputs.rollback_lock_id }}
+          REGION: ${{ inputs.region }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: bash .github/scripts/validate-teable-rollback.sh
+
+  deploy-ai:
+    name: Roll back teable.ai Cloud
+    needs: validate-lock
+    if: inputs.region == 'teable.ai'
+    uses: ./.github/workflows/manual-ecs-deploy.yml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      trigger: ${{ inputs.trigger }}
+      record_launch: false
+    secrets: inherit
+
+  deploy-cn:
+    name: Roll back teable.cn Cloud
+    needs: validate-lock
+    if: inputs.region == 'teable.cn'
+    uses: ./.github/workflows/manual-sealos-deploy.yaml
+    with:
+      image_tag: ${{ inputs.image_tag }}
+      trigger: ${{ inputs.trigger }}
+      record_launch: false
+    secrets: inherit
+
+  promote-ee:
+    name: Roll back EE latest
+    needs: validate-lock
+    uses: ./.github/workflows/promote-latest-ee.yaml
+    with:
+      release_id: ${{ inputs.image_tag }}
+    secrets: inherit
+
+  record-rollback:
+    name: Record successful rollback Launch
+    needs: [validate-lock, deploy-ai, deploy-cn, promote-ee]
+    if: >-
+      always() &&
+      needs.validate-lock.result == 'success' &&
+      needs.promote-ee.result == 'success' &&
+      ((inputs.region == 'teable.ai' && needs.deploy-ai.result == 'success') ||
+       (inputs.region == 'teable.cn' && needs.deploy-cn.result == 'success'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Rollback Launch and release lock
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          SOURCE_LAUNCH_ID: ${{ inputs.source_launch_id }}
+          ROLLBACK_LOCK_ID: ${{ inputs.rollback_lock_id }}
+          REGION: ${{ inputs.region }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          TRIGGER: ${{ inputs.trigger }}
+        run: bash .github/scripts/complete-teable-rollback.sh
+
+  notify-failure:
+    name: Report rollback failure
+    needs: [validate-lock, deploy-ai, deploy-cn, promote-ee, record-rollback]
+    if: >-
+      always() &&
+      (needs.validate-lock.result == 'failure' ||
+       needs.promote-ee.result == 'failure' ||
+       (inputs.region == 'teable.ai' && needs.deploy-ai.result != 'success') ||
+       (inputs.region == 'teable.cn' && needs.deploy-cn.result != 'success') ||
+       needs.record-rollback.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        if: needs.validate-lock.result == 'success'
+        uses: actions/checkout@v4
+
+      - name: Preserve failed rollback lock
+        if: needs.validate-lock.result == 'success'
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          SOURCE_LAUNCH_ID: ${{ inputs.source_launch_id }}
+          ROLLBACK_LOCK_ID: ${{ inputs.rollback_lock_id }}
+          ERROR_SUMMARY: 'Cloud deployment, EE latest promotion, or Launch recording failed'
+        run: bash .github/scripts/mark-teable-rollback-failed.sh
+
+      - name: Send Feishu failure notification
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "LARK_BOT_URL is not configured"
+            exit 1
+          fi
+
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          card_payload=$(jq -n \
+            --arg title "Rollback 失败 ${{ inputs.image_tag }}" \
+            --arg region "${{ inputs.region }}" \
+            --arg validate "${{ needs.validate-lock.result }}" \
+            --arg cloudAi "${{ needs.deploy-ai.result }}" \
+            --arg cloudCn "${{ needs.deploy-cn.result }}" \
+            --arg ee "${{ needs.promote-ee.result }}" \
+            --arg record "${{ needs.record-rollback.result }}" \
+            --arg url "$run_url" \
+            '{
+              "msg_type": "interactive",
+              "card": {
+                "header": {
+                  "title": {"tag": "plain_text", "content": $title},
+                  "template": "red"
+                },
+                "elements": [
+                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**环境**: " + $region + "\n**锁校验**: " + $validate + "\n**Cloud AI**: " + $cloudAi + "\n**Cloud CN**: " + $cloudCn + "\n**EE latest**: " + $ee + "\n**Launch 记录**: " + $record + "\n回滚锁保留至过期，请先核对线上 Cloud 与 EE latest 状态。\n[查看 Actions](" + $url + ")")}}
+                ]
+              }
+            }')
+          curl -fsS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$card_payload" >/dev/null


### PR DESCRIPTION
## What changed
- add a `Rollback Launch` orchestrator that rolls back the selected Cloud region and EE `latest` in parallel
- defer normal Launch recording inside the reusable Cloud deploy workflows during rollback
- validate the Launch-scoped rollback lock before deployment
- create a `Rollback` Launch only after Cloud and EE both succeed
- preserve failed rollback locks and send an actionable Feishu alert

## State ownership
Rollback state is stored only on the source Launch. This workflow does not update the Releases table or republish changelogs.

## Verification
- `bash -n` passed for all rollback scripts
- all modified/new workflow YAML parses with `js-yaml`
- mocked successful rollback created `Operation_Type=Rollback`, copied linked Releases/changelogs, and cleared the Launch lock
- mocked failure recorded `Rollback_Status=Failed` while preserving lock metadata