### PR TITLE
ci: bake the release-note annotation before the release-tag fan-out

### DIFF
--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -6,7 +6,8 @@ name: Promote teable EE to latest
 # Promotion turns a chosen build into the official release:
 #   1. ghcr: stamp release.<id> on the public packages from the staging
 #      source (skip if already stamped — re-promotes work after the beta
-#      twin is reaped), then move latest.
+#      twin is reaped), bake the release-note pointer annotation into the
+#      app index, then derive latest + aliases from it.
 #   2. Docker Hub: copy release.<id> + latest from ghcr (builds publish
 #      nothing to Docker Hub — this promotion is the only writer).
 #   3. Aliyun EE mirror: latest + release.<id>, including the canonical
@@ -35,6 +36,7 @@ env:
   REGISTRY_GITHUB: ghcr.io/teableio
   REGISTRY_DOCKERHUB: docker.io/teableio
   RELEASE_ID: ${{ github.event.client_payload.release_id || inputs.release_id }}
+  OSS_REPO: teableio/teable
 
 jobs:
   promote-latest:
@@ -79,6 +81,24 @@ jobs:
               docker buildx imagetools create \
                 --tag "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" \
                 "${REGISTRY_GITHUB}/${STAGING}:${BETA_TAG}"
+            fi
+
+            # Bake the release-note pointer into the app index BEFORE latest,
+            # the aliases, and the registry mirrors are derived from it —
+            # annotating rewrites the index (new digest), and doing it after
+            # the fan-out (as publish-release-note used to) left ghcr's
+            # release tag on a different digest than latest/Docker Hub/
+            # Aliyun. ghcr renders org.opencontainers.image.description as
+            # the version description. Idempotent: re-promotes re-apply the
+            # same annotation and land on the same digest. The URL may not
+            # resolve for the few minutes until publish-release-note creates
+            # the GitHub Release (and never does for a bare promote-ee),
+            # which matches how the old post-hoc stamp behaved.
+            if [ "$RELEASE" = "teable" ]; then
+              docker buildx imagetools create \
+                --annotation "index:org.opencontainers.image.description=Release note: https://github.com/${OSS_REPO}/releases/tag/${RELEASE_ID}" \
+                --tag "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" \
+                "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}"
             fi
 
             docker buildx imagetools create \

--- a/.github/workflows/publish-release-note.yaml
+++ b/.github/workflows/publish-release-note.yaml
@@ -159,39 +159,11 @@ jobs:
             echo "Created release ${RELEASE_ID}"
           fi
 
-      - name: Login to GitHub container registry
-        if: steps.mode.outputs.dry == 'false'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.PACKAGES_KEY }}
-
-      - name: Set up Docker Buildx
-        if: steps.mode.outputs.dry == 'false'
-        uses: docker/setup-buildx-action@v3
-
-      # ghcr shows a per-version description sourced from the
-      # org.opencontainers.image.description annotation on the manifest
-      # index. Keep this value short and label the canonical GitHub Release,
-      # where the complete reviewed note is published.
-      - name: Stamp ghcr version descriptions
-        env:
-          DRY: ${{ steps.mode.outputs.dry }}
-        run: |
-          set -euo pipefail
-          DESC="Release note: https://github.com/${OSS_REPO}/releases/tag/${RELEASE_ID}"
-          for image in teable teable-ee; do
-            ref="ghcr.io/teableio/${image}:${RELEASE_ID}"
-            if [ "$DRY" = "true" ]; then
-              echo "[dry-run] would re-stamp ${ref} with description: ${DESC}"
-              continue
-            fi
-            docker buildx imagetools create \
-              --annotation "index:org.opencontainers.image.description=${DESC}" \
-              --tag "${ref}" \
-              "${ref}"
-          done
+      # The ghcr version description (org.opencontainers.image.description
+      # pointing at the GitHub Release) is baked into the index by
+      # promote-latest-ee BEFORE latest/aliases/mirrors are derived from it.
+      # Re-annotating here after the fan-out would fork the release tag onto
+      # a new digest and desync it from latest and the mirrors.
 
       - name: Update Docker Hub What's New
         env:


### PR DESCRIPTION
## Background

`publish-release-note` re-annotated ghcr's `release.<id>` (the `org.opencontainers.image.description` pointer to the GitHub Release) AFTER `promote-latest-ee` had already derived `latest`/aliases from it and synced Docker Hub/Aliyun. Annotating rewrites the manifest index, so the ghcr release tag forked onto a new digest:

- `latest` and `release.*` stopped sharing a version row on ghcr even when they are the same image (observed on release.2320/2328 — content-identical, digests differ only by the annotation);
- the same release tag carried different digests on ghcr vs Docker Hub/Aliyun, breaking any cross-registry digest comparison/pinning.

## Changes

- **promote-latest-ee.yaml**: annotate `teable:release.<id>` in place right between the release stamp and everything derived from it. `latest`, the `teable-ee` aliases, the Docker Hub copies, and the Aliyun sync all now inherit the annotated index — one digest everywhere, and `latest`/`release.*` share a row on ghcr again. Idempotent on re-promotes (same annotation → same digest). Sandbox packages stay unannotated, matching current behavior.
- **publish-release-note.yaml**: drop the post-hoc "Stamp ghcr version descriptions" step and its now-unused ghcr login/buildx setup; left a comment pointing at the new home.

Note: the annotation URL is written a few minutes before the GitHub Release exists (promote runs first by design), and a bare `promote-ee` dispatch writes a URL that only materializes if a release note is later published — same semantics as the old post-hoc stamp, just earlier.

## Verification

- Both files parse cleanly with js-yaml.
- The annotated re-tag uses the same single-source `imagetools create` invocation the old step used; only its position in the pipeline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)