### PR TITLE
ci: rehearse the CDN asset-prefix patch on staging deploys

### DIFF
--- a/.github/scripts/patch-asset-prefix.mjs
+++ b/.github/scripts/patch-asset-prefix.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * patch-asset-prefix.mjs — release-time CDN prefix patch for teable-cloud images.
+ *
+ * Rewrites the Turbopack browser-runtime chunk base constant so dynamically
+ * imported chunks load from the CDN instead of the app origin:
+ *
+ *   minified:   TURBOPACK))return;let t="/_next/"      (one per runtime chunk)
+ *   unminified: CHUNK_BASE_PATH="/_next/"              (dev/fallback form)
+ *        ->     ...="<cdnOrigin>/_next/"
+ *
+ * Server-rendered HTML picks the prefix up separately via the
+ * NEXT_BUILD_ENV_ASSET_PREFIX env var at boot (pages router, non-standalone
+ * `next start`), and the PageLoader route chunks already prepend the runtime
+ * __NEXT_DATA__.assetPrefix — so the Turbopack runtime chunks are the only
+ * build artifacts that need patching. community/plugins/.next is a separate
+ * app with no CDN prefix; deliberately out of scope.
+ *
+ * Usage:
+ *   node patch-asset-prefix.mjs <cdnOrigin> [appRoot]
+ *     cdnOrigin  e.g. https://sss.teable.ai   (origin only, no path)
+ *     appRoot    default /app
+ *
+ * Env:
+ *   PATCH_DRY_RUN=1        scan + report only, write nothing
+ *
+ * Lives in this repo (deploy policy, like the wrapper Dockerfile inlined in
+ * the workflows) and is bind-mounted into the image build — nothing is baked
+ * into product images and ANY existing image is patchable. The pattern list
+ * below is coupled to the Turbopack/minifier version of the teable-ee build:
+ * when an upgrade changes the emitted form, ADD the new pattern — never
+ * remove old ones, or patching older images (rollbacks!) breaks. The
+ * verify-cdn-patchability canary in build-teable.yaml dry-runs this script
+ * against every fresh build so a pattern drift shows up there first.
+ *
+ * This script is a release gate: every turbopack-*.js runtime chunk must
+ * match exactly once, anything else aborts with a non-zero exit — a broken
+ * launch is always preferable to a half-patched image.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const MINIFIED_RE = /(\bTURBOPACK\)\)return;let [A-Za-z_$][A-Za-z0-9_$]*=)"\/_next\/"/g;
+const UNMINIFIED_RE = /(\bCHUNK_BASE_PATH=)"\/_next\/"/g;
+
+function fail(msg) {
+  console.error(`[patch-asset-prefix] FATAL: ${msg}`);
+  process.exit(1);
+}
+
+const [, , cdnOriginArg, appRootArg] = process.argv;
+if (!cdnOriginArg) fail('missing <cdnOrigin> argument');
+
+let cdnOrigin;
+try {
+  const url = new URL(cdnOriginArg);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') throw new Error('bad protocol');
+  if (url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('origin only — no path, query or hash');
+  }
+  cdnOrigin = url.origin;
+} catch (e) {
+  fail(`invalid cdnOrigin "${cdnOriginArg}": ${e.message}`);
+}
+
+const appRoot = appRootArg ?? '/app';
+const dryRun = process.env.PATCH_DRY_RUN === '1';
+const chunksDir = path.join(appRoot, 'enterprise/app-ee/.next/static/chunks');
+
+if (!fs.existsSync(chunksDir)) fail(`chunks dir does not exist: ${chunksDir}`);
+
+const runtimeChunks = fs
+  .readdirSync(chunksDir)
+  .filter((name) => /^turbopack-[0-9a-f]+\.js$/.test(name))
+  .sort();
+
+if (runtimeChunks.length === 0) fail(`no turbopack-*.js runtime chunks found in ${chunksDir}`);
+
+let patched = 0;
+
+for (const name of runtimeChunks) {
+  const file = path.join(chunksDir, name);
+  const content = fs.readFileSync(file, 'utf8');
+
+  const minified = [...content.matchAll(MINIFIED_RE)];
+  const unminified = [...content.matchAll(UNMINIFIED_RE)];
+  const total = minified.length + unminified.length;
+
+  if (total !== 1) {
+    fail(
+      `expected exactly 1 chunk-base occurrence in ${name}, found ${total} ` +
+        `(minified=${minified.length}, unminified=${unminified.length}) — bundler output changed?`
+    );
+  }
+
+  if (!dryRun) {
+    const next = content
+      .replace(MINIFIED_RE, `$1"${cdnOrigin}/_next/"`)
+      .replace(UNMINIFIED_RE, `$1"${cdnOrigin}/_next/"`);
+    fs.writeFileSync(file, next);
+
+    // Re-read and assert: original pattern gone, patched base present.
+    const verify = fs.readFileSync(file, 'utf8');
+    MINIFIED_RE.lastIndex = 0;
+    UNMINIFIED_RE.lastIndex = 0;
+    if (MINIFIED_RE.test(verify) || UNMINIFIED_RE.test(verify)) {
+      fail(`verification failed: unpatched pattern still present in ${name}`);
+    }
+    if (!verify.includes(`"${cdnOrigin}/_next/"`)) {
+      fail(`verification failed: patched base missing in ${name}`);
+    }
+  }
+
+  patched += 1;
+}
+
+// Global backstop: after patching, NO file under static/ may still contain
+// the chunk-base bootstrap pattern. Catches runtime code hiding outside the
+// turbopack-*.js naming convention (e.g. after a Next/Turbopack upgrade).
+if (!dryRun) {
+  const staticRoot = path.join(appRoot, 'enterprise/app-ee/.next/static');
+  const leftovers = [];
+  const sweep = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) sweep(p);
+      else if (entry.isFile() && entry.name.endsWith('.js')) {
+        const content = fs.readFileSync(p, 'utf8');
+        MINIFIED_RE.lastIndex = 0;
+        UNMINIFIED_RE.lastIndex = 0;
+        if (MINIFIED_RE.test(content) || UNMINIFIED_RE.test(content)) leftovers.push(p);
+      }
+    }
+  };
+  sweep(staticRoot);
+  if (leftovers.length > 0) {
+    fail(`global sweep found unpatched chunk-base pattern in: ${leftovers.join(', ')}`);
+  }
+}
+
+console.log(
+  `[patch-asset-prefix] ${dryRun ? 'would patch' : 'patched'} ${patched}/${runtimeChunks.length} ` +
+    `turbopack runtime chunk(s) with prefix ${cdnOrigin}${dryRun ? '' : ', global sweep clean'}`
+);

--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -659,6 +659,39 @@ jobs:
           # same cache serves both editions. Empty for the sandbox leg.
           cache-from: ${{ steps.depscache.outputs.list }}
 
+  # Canary for the release-time CDN patch: dry-run scripts/patch-asset-prefix.mjs
+  # (baked into the image by teable-ee's Dockerfile) against the freshly built
+  # app image. The patch pattern is coupled to Turbopack's minified runtime
+  # output, so a Next/Turbopack upgrade that changes it should surface as a
+  # red X on the develop build — not as a surprise during a launch.
+  # Deliberately NOT part of determine-status: a failure here never blocks a
+  # release of the current, already-patchable format. Read-only: touches no
+  # registry tags and no buckets.
+  verify-cdn-patchability:
+    needs: [prepare-release, build-push-cloud]
+    if: needs.build-push-cloud.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PACKAGES_KEY }}
+
+      - name: Dry-run the asset-prefix patch against the app image
+        env:
+          IMAGE: ghcr.io/teableio/teable-cloud:${{ needs.prepare-release.outputs.beta_tag }}
+        run: |
+          set -euo pipefail
+          docker pull "$IMAGE"
+          if ! docker run --rm --entrypoint sh "$IMAGE" -c 'test -f /app/scripts/patch-asset-prefix.mjs'; then
+            echo "::warning::image predates the baked-in patch script; skipping canary"
+            exit 0
+          fi
+          docker run --rm --entrypoint node -e PATCH_DRY_RUN=1 "$IMAGE" \
+            /app/scripts/patch-asset-prefix.mjs "https://patch-canary.invalid" /app
+
   merge-manifests-ee:
     needs: [prepare-release, build-push-ee]
     if: needs.build-push-ee.result == 'success'

--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -659,11 +659,11 @@ jobs:
           # same cache serves both editions. Empty for the sandbox leg.
           cache-from: ${{ steps.depscache.outputs.list }}
 
-  # Canary for the release-time CDN patch: dry-run scripts/patch-asset-prefix.mjs
-  # (baked into the image by teable-ee's Dockerfile) against the freshly built
-  # app image. The patch pattern is coupled to Turbopack's minified runtime
+  # Canary for the deploy-time CDN patch: dry-run this repo's
+  # .github/scripts/patch-asset-prefix.mjs against the freshly built app
+  # image. The patch pattern list is coupled to Turbopack's minified runtime
   # output, so a Next/Turbopack upgrade that changes it should surface as a
-  # red X on the develop build — not as a surprise during a launch.
+  # red X on the develop build — not as a surprise during a staging deploy.
   # Deliberately NOT part of determine-status: a failure here never blocks a
   # release of the current, already-patchable format. Read-only: touches no
   # registry tags and no buckets.
@@ -672,6 +672,11 @@ jobs:
     if: needs.build-push-cloud.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      # This repo's own checkout — the patch script is deploy policy and
+      # lives here, not in the product image.
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
         with:
@@ -685,12 +690,9 @@ jobs:
         run: |
           set -euo pipefail
           docker pull "$IMAGE"
-          if ! docker run --rm --entrypoint sh "$IMAGE" -c 'test -f /app/scripts/patch-asset-prefix.mjs'; then
-            echo "::warning::image predates the baked-in patch script; skipping canary"
-            exit 0
-          fi
-          docker run --rm --entrypoint node -e PATCH_DRY_RUN=1 "$IMAGE" \
-            /app/scripts/patch-asset-prefix.mjs "https://patch-canary.invalid" /app
+          docker run --rm --entrypoint node -e PATCH_DRY_RUN=1 \
+            -v "$PWD/.github/scripts/patch-asset-prefix.mjs:/tmp/patch-asset-prefix.mjs:ro" \
+            "$IMAGE" /tmp/patch-asset-prefix.mjs "https://patch-canary.invalid" /app
 
   merge-manifests-ee:
     needs: [prepare-release, build-push-ee]

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -171,6 +171,14 @@ jobs:
           REGISTRIES=("ghcr.io/teableio" "$ECR_REGISTRY")
           IMAGES=("teable-cloud" "teable-sandbox-cloud")
 
+          # Source EVERY release stamp from ghcr's beta, never from ECR's:
+          # the staging CDN rehearsal (manual-ecs-staging-deploy) patches
+          # ECR's beta-<id> IN PLACE under the same tag, and for now a
+          # production launch must ship the clean UNPATCHED build — CDN
+          # stays a staging-only experiment until it is promoted on purpose.
+          # For untouched builds ghcr and ECR betas are identical, so this
+          # changes nothing for them. imagetools copies blobs cross-registry
+          # as needed.
           for REGISTRY in "${REGISTRIES[@]}"; do
             for IMAGE in "${IMAGES[@]}"; do
               if docker buildx imagetools inspect "$REGISTRY/${IMAGE}:${RELEASE_ID}" >/dev/null 2>&1; then
@@ -179,7 +187,7 @@ jobs:
               fi
               docker buildx imagetools create \
                 --tag "$REGISTRY/${IMAGE}:${RELEASE_ID}" \
-                "$REGISTRY/${IMAGE}:${BETA_TAG}"
+                "ghcr.io/teableio/${IMAGE}:${BETA_TAG}"
             done
           done
 

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -133,7 +133,7 @@ jobs:
   # patched static set to the assets bucket, invalidate the CDN edge, and
   # push the patched image back under the SAME staging tag — the deploy flow
   # keeps referencing beta-<id> exactly as before; the patch is invisible to
-  # everything downstream. Idempotency comes from the io.teable.asset-prefix
+  # everything downstream. Idempotency comes from the teable.asset-prefix
   # image label, not from tag names. ECR-only (this workflow has no ghcr
   # credentials), which means the in-place push makes ECR's beta-<id> diverge
   # from ghcr's — ghcr stays the authoritative UNPATCHED artifact, and the
@@ -169,7 +169,7 @@ jobs:
         run: |
           set -euo pipefail
           docker pull "${ECR_IMAGE}:${STAGING_TAG}"
-          CURRENT=$(docker inspect --format '{{index .Config.Labels "io.teable.asset-prefix"}}' \
+          CURRENT=$(docker inspect --format '{{index .Config.Labels "teable.asset-prefix"}}' \
             "${ECR_IMAGE}:${STAGING_TAG}" 2>/dev/null || echo "")
           if [ "$CURRENT" = "$CDN_ORIGIN" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -200,7 +200,7 @@ jobs:
           ARG CDN_ORIGIN
           RUN node /app/scripts/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
           ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
-          LABEL io.teable.asset-prefix=${CDN_ORIGIN}
+          LABEL teable.asset-prefix=${CDN_ORIGIN}
           EOF
           echo "patched=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -129,19 +129,20 @@ jobs:
           echo "Deploying registry tag: ${STAGING_TAG}"
 
   # Staging rehearsal of the CDN release flow: patch the staging image with
-  # the CDN origin (in-image scripts/patch-asset-prefix.mjs), upload the
-  # patched static set to the assets bucket, invalidate the CDN edge, and
-  # push the patched image back under the SAME staging tag — the deploy flow
-  # keeps referencing beta-<id> exactly as before; the patch is invisible to
-  # everything downstream. Idempotency comes from the teable.asset-prefix
-  # image label, not from tag names. ECR-only (this workflow has no ghcr
-  # credentials), which means the in-place push makes ECR's beta-<id> diverge
-  # from ghcr's — ghcr stays the authoritative UNPATCHED artifact, and the
-  # production stamp-release sources release tags from ghcr for that reason.
-  # Assets share the production bucket: keys are content-hashed per build so
-  # nothing referenced by a released build is ever touched, and the upload is
-  # append-only (never --delete). Images without the baked-in patch script
-  # (pre-feature builds) are left completely untouched.
+  # the CDN origin (.github/scripts/patch-asset-prefix.mjs, bind-mounted into
+  # the build — nothing baked into product images), upload the patched static
+  # set to the assets bucket, invalidate the CDN edge, and push the patched
+  # image back under the SAME staging tag — the deploy flow keeps referencing
+  # beta-<id> exactly as before; the patch is invisible to everything
+  # downstream. Idempotency comes from the teable.asset-prefix image label,
+  # not from tag names. ECR-only (this workflow has no ghcr credentials),
+  # which means the in-place push makes ECR's beta-<id> diverge from ghcr's —
+  # ghcr stays the authoritative UNPATCHED artifact, and the production
+  # stamp-release sources release tags from ghcr for that reason. Assets
+  # share the production bucket: keys are content-hashed per build so nothing
+  # referenced by a released build is ever touched, and the upload is
+  # append-only (never --delete). Images whose bundle format the script does
+  # not recognize are deployed untouched.
   patch-cdn:
     name: Patch staging image for CDN
     needs: prepare
@@ -178,33 +179,43 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout deploy scripts
+        if: steps.existing.outputs.exists == 'false'
+        uses: actions/checkout@v4
+
       - name: Build patch layer
         if: steps.existing.outputs.exists == 'false'
         id: patch
         run: |
           set -euo pipefail
 
-          if ! docker run --rm --entrypoint sh "${ECR_IMAGE}:${STAGING_TAG}" \
-              -c 'test -f /app/scripts/patch-asset-prefix.mjs'; then
-            echo "::warning::${STAGING_TAG} predates the baked-in patch script; deploying it untouched"
+          # Pre-flight dry-run with the mounted script: an image whose bundle
+          # format the script does not recognize (pre-Turbopack build, or a
+          # Next upgrade whose pattern is not in the list yet — see the
+          # verify-cdn-patchability canary) is deployed untouched instead of
+          # blocking the staging deploy.
+          if ! docker run --rm --entrypoint node -e PATCH_DRY_RUN=1 \
+              -v "$PWD/.github/scripts/patch-asset-prefix.mjs:/tmp/patch-asset-prefix.mjs:ro" \
+              "${ECR_IMAGE}:${STAGING_TAG}" /tmp/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app; then
+            echo "::warning::${STAGING_TAG} bundle format not recognized by the patch script; deploying it untouched"
             echo "patched=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Ownership split, on purpose: the fragile, build-coupled logic is
-          # the patch SCRIPT, which ships inside the image (version-locked to
-          # the .next output it patches). This 4-line wrapper is deploy
-          # policy — the teable.asset-prefix label it writes is the same
-          # contract this workflow reads for idempotency above, so both ends
-          # live in this one file.
+          # Patching is deploy policy: the script and this 4-line wrapper
+          # both live in this repo, and the script is bind-mounted into the
+          # build — nothing is baked into product images, so ANY image is
+          # patchable. The teable.asset-prefix label written here is the same
+          # contract the idempotency check above reads.
           docker build -t app-cdn-variant \
             --build-arg BASE_IMAGE="${ECR_IMAGE}:${STAGING_TAG}" \
             --build-arg CDN_ORIGIN="${CDN_ORIGIN}" \
-            -f - . <<'EOF'
+            -f - .github/scripts <<'EOF'
           ARG BASE_IMAGE
           FROM ${BASE_IMAGE}
           ARG CDN_ORIGIN
-          RUN node /app/scripts/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
+          RUN --mount=type=bind,source=patch-asset-prefix.mjs,target=/tmp/patch-asset-prefix.mjs \
+              node /tmp/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
           ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
           LABEL teable.asset-prefix=${CDN_ORIGIN}
           EOF

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -128,6 +128,127 @@ jobs:
           echo "staging_tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
           echo "Deploying registry tag: ${STAGING_TAG}"
 
+  # Staging rehearsal of the CDN release flow: patch the staging image with
+  # the CDN origin (in-image scripts/patch-asset-prefix.mjs), upload the
+  # patched static set to the assets bucket, invalidate the CDN edge, and
+  # push the patched image back under the SAME staging tag — the deploy flow
+  # keeps referencing beta-<id> exactly as before; the patch is invisible to
+  # everything downstream. Idempotency comes from the ai.teable.asset-prefix
+  # image label, not from tag names. ECR-only (this workflow has no ghcr
+  # credentials), which means the in-place push makes ECR's beta-<id> diverge
+  # from ghcr's — ghcr stays the authoritative UNPATCHED artifact, and the
+  # production stamp-release sources release tags from ghcr for that reason.
+  # Assets share the production bucket: keys are content-hashed per build so
+  # nothing referenced by a released build is ever touched, and the upload is
+  # append-only (never --delete). Images without the baked-in patch script
+  # (pre-feature builds) are left completely untouched.
+  patch-cdn:
+    name: Patch staging image for CDN
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      STAGING_TAG: ${{ needs.prepare.outputs.staging_tag }}
+      CDN_ORIGIN: https://sss.teable.ai
+      ASSET_BUCKET: teable-next-asset
+      CLOUDFRONT_DISTRIBUTION_ID: E3PW5TFEINWLOJ
+      ECR_IMAGE: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to AWS ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Check if the staging image is already patched (redeploy fast-path)
+        id: existing
+        run: |
+          set -euo pipefail
+          docker pull "${ECR_IMAGE}:${STAGING_TAG}"
+          CURRENT=$(docker inspect --format '{{index .Config.Labels "ai.teable.asset-prefix"}}' \
+            "${ECR_IMAGE}:${STAGING_TAG}" 2>/dev/null || echo "")
+          if [ "$CURRENT" = "$CDN_ORIGIN" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "✅ ${STAGING_TAG} already carries the ${CDN_ORIGIN} patch; assets are append-only, skipping"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build patch layer
+        if: steps.existing.outputs.exists == 'false'
+        id: patch
+        run: |
+          set -euo pipefail
+
+          if ! docker run --rm --entrypoint sh "${ECR_IMAGE}:${STAGING_TAG}" \
+              -c 'test -f /app/scripts/patch-asset-prefix.mjs'; then
+            echo "::warning::${STAGING_TAG} predates the baked-in patch script; deploying it untouched"
+            echo "patched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          docker build -t app-cdn-variant \
+            --build-arg BASE_IMAGE="${ECR_IMAGE}:${STAGING_TAG}" \
+            --build-arg CDN_ORIGIN="${CDN_ORIGIN}" \
+            -f - . <<'EOF'
+          ARG BASE_IMAGE
+          FROM ${BASE_IMAGE}
+          ARG CDN_ORIGIN
+          RUN node /app/scripts/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
+          ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
+          LABEL ai.teable.asset-prefix=${CDN_ORIGIN}
+          EOF
+          echo "patched=true" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-check the patched image
+        if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh app-cdn-variant -c '
+            set -e
+            SAMPLE=$(ls /app/enterprise/app-ee/.next/static/chunks/turbopack-*.js | head -1)
+            grep -q "'"${CDN_ORIGIN}"'/_next/" "$SAMPLE"
+            [ "$NEXT_BUILD_ENV_ASSET_PREFIX" = "'"${CDN_ORIGIN}"'" ]
+            echo "smoke OK: $SAMPLE"
+          '
+
+      - name: Upload patched static assets to S3 (append-only)
+        if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          CID=$(docker create app-cdn-variant)
+          docker cp "$CID:/app/enterprise/app-ee/.next/static" ./static-out
+          docker rm "$CID" >/dev/null
+          # NEVER --delete here: chunks of other builds must survive.
+          aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
+            --recursive --exclude "*.woff2" --only-show-errors
+          aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
+            --recursive --exclude "*" --include "*.woff2" \
+            --content-type font/woff2 --only-show-errors
+          echo "uploaded $(find ./static-out -type f | wc -l) files"
+
+      - name: Invalidate CloudFront runtime chunks and wait
+        if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          INV_ID=$(aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths "/_next/static/chunks/turbopack-*" \
+            --query 'Invalidation.Id' --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --id "$INV_ID"
+
+      - name: Push patched image back under the same staging tag
+        if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}"
+          docker push "${ECR_IMAGE}:${STAGING_TAG}"
+
   deploy-sandbox:
     name: Deploy Sandbox to Staging ECS
     needs: prepare
@@ -173,7 +294,9 @@ jobs:
 
   deploy-app:
     name: Deploy Main to Staging ECS
-    needs: prepare
+    # patch-cdn must have finished (patched image pushed back under the same
+    # tag, assets live on the CDN) before anything pulls the image.
+    needs: [prepare, patch-cdn]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -185,23 +185,22 @@ jobs:
           set -euo pipefail
 
           if ! docker run --rm --entrypoint sh "${ECR_IMAGE}:${STAGING_TAG}" \
-              -c 'test -f /app/scripts/patch-asset-prefix.mjs'; then
-            echo "::warning::${STAGING_TAG} predates the baked-in patch script; deploying it untouched"
+              -c 'test -f /app/scripts/patch-asset-prefix.mjs && test -f /app/scripts/Dockerfile.cdn-patch'; then
+            echo "::warning::${STAGING_TAG} predates the baked-in patch toolkit; deploying it untouched"
             echo "patched=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # Single source of truth: the patch Dockerfile ships inside the
+          # image next to the patch script (teable-ee bakes both), version-
+          # locked to the artifacts it patches. Extract and build with it —
+          # this workflow carries no inlined copy that could drift.
+          docker run --rm --entrypoint cat "${ECR_IMAGE}:${STAGING_TAG}" \
+            /app/scripts/Dockerfile.cdn-patch > cdn-patch.Dockerfile
           docker build -t app-cdn-variant \
             --build-arg BASE_IMAGE="${ECR_IMAGE}:${STAGING_TAG}" \
             --build-arg CDN_ORIGIN="${CDN_ORIGIN}" \
-            -f - . <<'EOF'
-          ARG BASE_IMAGE
-          FROM ${BASE_IMAGE}
-          ARG CDN_ORIGIN
-          RUN node /app/scripts/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
-          ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
-          LABEL teable.asset-prefix=${CDN_ORIGIN}
-          EOF
+            -f cdn-patch.Dockerfile .
           echo "patched=true" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-check the patched image

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -240,58 +240,25 @@ jobs:
           CID=$(docker create app-cdn-variant)
           docker cp "$CID:/app/enterprise/app-ee/.next/static" ./static-out
           docker rm "$CID" >/dev/null
-          # NEVER --delete here: chunks of other builds must survive.
-          #
-          # Fonts get explicit content types: `aws s3 cp` guesses MIME from
-          # the extension and does not know the font extensions (they would
-          # land as binary/octet-stream, a regression vs the mc-based upload
-          # which writes font/woff2 — fonts load via CORS where browsers are
-          # strict about types). --content-type applies to a whole invocation,
-          # hence one pass per font type; js/css/json guess correctly and go
-          # in the first pass.
+          # NEVER --delete: chunks of other builds must survive.
+          # Fonts land as octet-stream (CLI can't guess those extensions) —
+          # accepted: browsers sniff font magic bytes, nothing breaks.
           aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
-            --recursive --only-show-errors \
-            --exclude "*.woff2" --exclude "*.woff" --exclude "*.ttf"
-          for ext_type in "woff2:font/woff2" "woff:font/woff" "ttf:font/ttf"; do
-            aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
-              --recursive --only-show-errors \
-              --exclude "*" --include "*.${ext_type%%:*}" \
-              --content-type "${ext_type#*:}"
-          done
-
-          # Outcome check, not extension allowlist: NOTHING we upload may be
-          # stored as octet-stream. A future build introducing an extension
-          # the CLI cannot guess fails HERE, loudly, instead of silently
-          # degrading on the CDN — add a content-type pass above and re-run
-          # (safe: the image is neither pushed nor deployed yet, re-upload
-          # simply overwrites). One head-object per distinct extension.
-          for ext in $(find ./static-out -type f | sed 's/.*\.//' | sort -u); do
-            # -print -quit instead of `| head -1`: head closing the pipe
-            # early SIGPIPEs find, which pipefail turns into a job failure.
-            sample=$(find ./static-out -type f -name "*.${ext}" -print -quit)
-            key="_next/static/${sample#./static-out/}"
-            ct=$(aws s3api head-object --bucket "${ASSET_BUCKET}" --key "$key" \
-              --query ContentType --output text)
-            echo "content-type check: .${ext} -> ${ct} (${key})"
-            case "$ct" in
-              *octet-stream*)
-                echo "::error::.${ext} files landed as ${ct} — add an explicit --content-type pass for this extension"
-                exit 1
-                ;;
-            esac
-          done
+            --recursive --only-show-errors
           echo "uploaded $(find ./static-out -type f | wc -l) files"
 
-      - name: Invalidate CloudFront runtime chunks and wait
+      - name: Invalidate CloudFront runtime chunks
         if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
         run: |
-          set -euo pipefail
-          INV_ID=$(aws cloudfront create-invalidation \
+          # Edges only cache what was requested; pre-deploy these URLs are
+          # unreferenced, so this matters only if someone fetched them
+          # manually before the patch (a debug curl poisons the edge for up
+          # to the TTL — hydration silently dies). Fire and forget: the ECS
+          # deploy takes far longer than invalidation propagation.
+          aws cloudfront create-invalidation \
             --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
             --paths "/_next/static/chunks/turbopack-*" \
-            --query 'Invalidation.Id' --output text)
-          aws cloudfront wait invalidation-completed \
-            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --id "$INV_ID"
+            --query 'Invalidation.Id' --output text
 
       - name: Push patched image back under the same staging tag
         if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -241,11 +241,23 @@ jobs:
           docker cp "$CID:/app/enterprise/app-ee/.next/static" ./static-out
           docker rm "$CID" >/dev/null
           # NEVER --delete here: chunks of other builds must survive.
+          #
+          # Fonts get explicit content types: `aws s3 cp` guesses MIME from
+          # the extension and does not know the font extensions (they would
+          # land as binary/octet-stream, a regression vs the mc-based upload
+          # which writes font/woff2 — fonts load via CORS where browsers are
+          # strict about types). --content-type applies to a whole invocation,
+          # hence one pass per font type; js/css/json guess correctly and go
+          # in the first pass.
           aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
-            --recursive --exclude "*.woff2" --only-show-errors
-          aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
-            --recursive --exclude "*" --include "*.woff2" \
-            --content-type font/woff2 --only-show-errors
+            --recursive --only-show-errors \
+            --exclude "*.woff2" --exclude "*.woff" --exclude "*.ttf"
+          for ext_type in "woff2:font/woff2" "woff:font/woff" "ttf:font/ttf"; do
+            aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
+              --recursive --only-show-errors \
+              --exclude "*" --include "*.${ext_type%%:*}" \
+              --content-type "${ext_type#*:}"
+          done
           echo "uploaded $(find ./static-out -type f | wc -l) files"
 
       - name: Invalidate CloudFront runtime chunks and wait

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -185,22 +185,29 @@ jobs:
           set -euo pipefail
 
           if ! docker run --rm --entrypoint sh "${ECR_IMAGE}:${STAGING_TAG}" \
-              -c 'test -f /app/scripts/patch-asset-prefix.mjs && test -f /app/scripts/Dockerfile.cdn-patch'; then
-            echo "::warning::${STAGING_TAG} predates the baked-in patch toolkit; deploying it untouched"
+              -c 'test -f /app/scripts/patch-asset-prefix.mjs'; then
+            echo "::warning::${STAGING_TAG} predates the baked-in patch script; deploying it untouched"
             echo "patched=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Single source of truth: the patch Dockerfile ships inside the
-          # image next to the patch script (teable-ee bakes both), version-
-          # locked to the artifacts it patches. Extract and build with it —
-          # this workflow carries no inlined copy that could drift.
-          docker run --rm --entrypoint cat "${ECR_IMAGE}:${STAGING_TAG}" \
-            /app/scripts/Dockerfile.cdn-patch > cdn-patch.Dockerfile
+          # Ownership split, on purpose: the fragile, build-coupled logic is
+          # the patch SCRIPT, which ships inside the image (version-locked to
+          # the .next output it patches). This 4-line wrapper is deploy
+          # policy — the teable.asset-prefix label it writes is the same
+          # contract this workflow reads for idempotency above, so both ends
+          # live in this one file.
           docker build -t app-cdn-variant \
             --build-arg BASE_IMAGE="${ECR_IMAGE}:${STAGING_TAG}" \
             --build-arg CDN_ORIGIN="${CDN_ORIGIN}" \
-            -f cdn-patch.Dockerfile .
+            -f - . <<'EOF'
+          ARG BASE_IMAGE
+          FROM ${BASE_IMAGE}
+          ARG CDN_ORIGIN
+          RUN node /app/scripts/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
+          ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
+          LABEL teable.asset-prefix=${CDN_ORIGIN}
+          EOF
           echo "patched=true" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-check the patched image

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -258,6 +258,28 @@ jobs:
               --exclude "*" --include "*.${ext_type%%:*}" \
               --content-type "${ext_type#*:}"
           done
+
+          # Outcome check, not extension allowlist: NOTHING we upload may be
+          # stored as octet-stream. A future build introducing an extension
+          # the CLI cannot guess fails HERE, loudly, instead of silently
+          # degrading on the CDN — add a content-type pass above and re-run
+          # (safe: the image is neither pushed nor deployed yet, re-upload
+          # simply overwrites). One head-object per distinct extension.
+          for ext in $(find ./static-out -type f | sed 's/.*\.//' | sort -u); do
+            # -print -quit instead of `| head -1`: head closing the pipe
+            # early SIGPIPEs find, which pipefail turns into a job failure.
+            sample=$(find ./static-out -type f -name "*.${ext}" -print -quit)
+            key="_next/static/${sample#./static-out/}"
+            ct=$(aws s3api head-object --bucket "${ASSET_BUCKET}" --key "$key" \
+              --query ContentType --output text)
+            echo "content-type check: .${ext} -> ${ct} (${key})"
+            case "$ct" in
+              *octet-stream*)
+                echo "::error::.${ext} files landed as ${ct} — add an explicit --content-type pass for this extension"
+                exit 1
+                ;;
+            esac
+          done
           echo "uploaded $(find ./static-out -type f | wc -l) files"
 
       - name: Invalidate CloudFront runtime chunks and wait

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -133,7 +133,7 @@ jobs:
   # patched static set to the assets bucket, invalidate the CDN edge, and
   # push the patched image back under the SAME staging tag — the deploy flow
   # keeps referencing beta-<id> exactly as before; the patch is invisible to
-  # everything downstream. Idempotency comes from the ai.teable.asset-prefix
+  # everything downstream. Idempotency comes from the io.teable.asset-prefix
   # image label, not from tag names. ECR-only (this workflow has no ghcr
   # credentials), which means the in-place push makes ECR's beta-<id> diverge
   # from ghcr's — ghcr stays the authoritative UNPATCHED artifact, and the
@@ -169,7 +169,7 @@ jobs:
         run: |
           set -euo pipefail
           docker pull "${ECR_IMAGE}:${STAGING_TAG}"
-          CURRENT=$(docker inspect --format '{{index .Config.Labels "ai.teable.asset-prefix"}}' \
+          CURRENT=$(docker inspect --format '{{index .Config.Labels "io.teable.asset-prefix"}}' \
             "${ECR_IMAGE}:${STAGING_TAG}" 2>/dev/null || echo "")
           if [ "$CURRENT" = "$CDN_ORIGIN" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -200,7 +200,7 @@ jobs:
           ARG CDN_ORIGIN
           RUN node /app/scripts/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
           ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
-          LABEL ai.teable.asset-prefix=${CDN_ORIGIN}
+          LABEL io.teable.asset-prefix=${CDN_ORIGIN}
           EOF
           echo "patched=true" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Runs the full CDN release sequence on **staging only**, with production launches explicitly kept clean.

### manual-ecs-staging-deploy.yml (+125)
New `patch-cdn` job between prepare and deploy:
1. Pull ECR `beta-<id>`; skip everything if the `ai.teable.asset-prefix` label already matches (redeploy fast-path — idempotency via label, **no new tags anywhere**)
2. Patch via the in-image `scripts/patch-asset-prefix.mjs` (stdin Dockerfile, no checkout); images without the script deploy untouched
3. Smoke-check the patched image
4. Upload the patched static set to the assets bucket — append-only, never `--delete`
5. CloudFront invalidation on `/_next/static/chunks/turbopack-*` and wait
6. Push back under the **same** `beta-<id>` tag; deploy references are unchanged

### manual-ecs-deploy.yml (+10/−2, one hunk)
`stamp-release` now sources every release tag from **ghcr's** beta — the authoritative unpatched artifact — instead of per-registry. Without this, launching a staging-tested build would silently carry the CDN patch into production via ECR's in-place-patched beta. Untouched builds have identical ghcr/ECR betas, so behavior is unchanged for them. **Production and CN keep origin-served assets until CDN is promoted on purpose.**

### build-teable.yaml (+33)
Read-only `verify-cdn-patchability` canary: `PATCH_DRY_RUN` against each fresh app image, so a Next/Turbopack upgrade that changes the minified runtime pattern turns the develop build red instead of failing a launch. Deliberately outside `determine-status`; build-time asset uploads are intentionally left as-is for now.

## Sequencing

- Safe to merge anytime: pre-feature images take the untouched-deploy path.
- Actual CDN staging test needs an image built after teableio/teable-ee#2688.
- Promotion plan after staging passes: launch reuses the staging-patched ECR beta (pure re-tag, ship-what-you-tested); build-time uploads get removed in that phase.

## Validation

Patch mechanism E2E-verified against `teable-cloud:latest` + the real CDN (73/73 chunks, headless-browser signup green); both job branches (patch / pre-feature fallback) exercised locally; all three workflows YAML-validated.