### PR TITLE
ci: build cloud images for arm64 alongside amd64

### DIFF
--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -75,6 +75,7 @@ jobs:
       ee_matrix_json: ${{ steps.release.outputs.ee_matrix_json }}
       ee_target_matrix_json: ${{ steps.release.outputs.ee_target_matrix_json }}
       cloud_matrix_json: ${{ steps.release.outputs.cloud_matrix_json }}
+      cloud_target_matrix_json: ${{ steps.release.outputs.cloud_target_matrix_json }}
       release_id: ${{ steps.release.outputs.release_id }}
       release_timestamp: ${{ steps.release.outputs.release_timestamp }}
       release_sequence: ${{ steps.release.outputs.release_sequence }}
@@ -122,7 +123,8 @@ jobs:
           # place. release_image/alias_image are where promotion publishes.
           EE_TARGET_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-staging","release_image":"teable","alias_image":"teable-ee"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","release_image":"teable-sandbox","alias_image":"teable-sandbox-ee"}]}'
           EE_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-staging","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"app","file":"Dockerfile","image":"teable-staging","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"}]}'
-          CLOUD_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-cloud","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox-cloud","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"}]}'
+          CLOUD_TARGET_MATRIX_JSON='{"include":[{"target":"app","image":"teable-cloud"},{"target":"sandbox","image":"teable-sandbox-cloud"}]}'
+          CLOUD_MATRIX_JSON='{"include":[{"target":"app","file":"Dockerfile","image":"teable-cloud","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"app","file":"Dockerfile","image":"teable-cloud","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox-cloud","platform":"linux/amd64","platform_key":"linux-amd64","runner":"ubuntu-latest"},{"target":"sandbox","file":"Dockerfile.sandbox","image":"teable-sandbox-cloud","platform":"linux/arm64","platform_key":"linux-arm64","runner":"ubuntu-24.04-arm"}]}'
 
           if [ -n "$INPUT_RELEASE_ID" ]; then
             RELEASE_ID="$INPUT_RELEASE_ID"
@@ -162,6 +164,7 @@ jobs:
             echo "ee_target_matrix_json=$EE_TARGET_MATRIX_JSON"
             echo "ee_matrix_json=$EE_MATRIX_JSON"
             echo "cloud_matrix_json=$CLOUD_MATRIX_JSON"
+            echo "cloud_target_matrix_json=$CLOUD_TARGET_MATRIX_JSON"
             echo "release_id=$RELEASE_ID"
             echo "release_timestamp=$RELEASE_TIMESTAMP"
             echo "release_sequence=$RELEASE_SEQUENCE"
@@ -516,9 +519,16 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Cloud images are amd64-only, so they push their tags directly — no digest
-  # merge needed. Edition-specific bits: CLOUD edition flag, Sentry sourcemap
-  # upload, CDN asset prefix, and the Next static asset upload config.
+  # Cloud images are multi-arch (amd64 + arm64, native runners): each leg
+  # pushes by digest and merge-manifests-cloud stitches the beta manifest,
+  # mirroring the EE flow. Edition-specific bits: CLOUD edition flag, Sentry
+  # sourcemap upload, CDN asset prefix, and the Next static asset upload
+  # config. Both legs keep IDENTICAL build args — including the sourcemap and
+  # asset uploads — because the frontend is compiled per-leg and content
+  # hashes are not guaranteed to match across arches: if only amd64 uploaded,
+  # an arm64 image whose chunks hashed differently would reference CDN assets
+  # that were never uploaded. Re-uploading is idempotent (content-hashed S3
+  # keys, checksum-deduped Sentry artifacts), so the duplicate is harmless.
   # Deliberately NOT gated on ensure-agent-base: the cloud images don't
   # consume the agent base, and in the old two-workflow world a base failure
   # never stopped the cloud images from being built and pushed (only the
@@ -548,11 +558,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.18.0
-
-      - name: Compose image tags
-        id: tags
-        run: |
-          echo "list=${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}:${{ needs.prepare-release.outputs.beta_tag }}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare generated Docker contexts
         if: matrix.file == 'Dockerfile'
@@ -623,14 +628,13 @@ jobs:
             echo 'CACHE_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: dockers/teable/${{ matrix.file }}
           platforms: ${{ matrix.platform }}
-          tags: ${{ steps.tags.outputs.list }}
           build-args: |
             ENABLE_CSP=false
             NEXT_BUILD_ENV_EDITION=CLOUD
@@ -643,12 +647,27 @@ jobs:
             BUILD_VERSION=${{ needs.prepare-release.outputs.release_id }}
             FRONTEND_RELEASE=${{ needs.prepare-release.outputs.release_id }}
             GIT_COMMIT_SHA=${{ needs.prepare-release.outputs.source_sha }}
-          push: true
+          outputs: type=image,name=${{ env.REGISTRY_GITHUB }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           provenance: false
           # Import-only scoped deps cache — the deps stages are edition-
           # independent (the edition build-arg is consumed after them), so the
           # same cache serves both editions. Empty for the sandbox leg.
           cache-from: ${{ steps.depscache.outputs.list }}
+
+      - name: Export digest artifact
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.platform_key }}.digest"
+
+      # The cloud- prefix keeps these artifacts out of the EE merge's
+      # digests-<target>-linux-* download pattern (targets overlap).
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-cloud-${{ matrix.target }}-${{ matrix.platform_key }}
+          path: /tmp/digests/${{ matrix.platform_key }}.digest
+          if-no-files-found: error
+          retention-days: 1
 
   # Canary for the deploy-time CDN patch: dry-run this repo's
   # .github/scripts/patch-asset-prefix.mjs against the freshly built app
@@ -658,9 +677,14 @@ jobs:
   # Deliberately NOT part of determine-status: a failure here never blocks a
   # release of the current, already-patchable format. Read-only: touches no
   # registry tags and no buckets.
+  #
+  # Gated on merge-manifests-cloud (not build-push-cloud): the cloud legs
+  # push by digest, so the beta tag this job pulls only exists once the
+  # manifest is stitched. The amd64 runner resolves the amd64 variant from
+  # the manifest list — the CDN-fronted one the deploy patch targets.
   verify-cdn-patchability:
-    needs: [prepare-release, build-push-cloud]
-    if: needs.build-push-cloud.result == 'success'
+    needs: [prepare-release, merge-manifests-cloud]
+    if: needs.merge-manifests-cloud.result == 'success'
     runs-on: ubuntu-latest
     steps:
       # This repo's own checkout — the patch script is deploy policy and
@@ -752,9 +776,58 @@ jobs:
 
   # ── Cloud distribution chain ───────────────────────────────────────────
 
-  sync-ecr:
+  merge-manifests-cloud:
     needs: [prepare-release, build-push-cloud]
-    if: needs.prepare-release.outputs.mode == 'release' && needs.build-push-cloud.result == 'success'
+    if: needs.build-push-cloud.result == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-release.outputs.cloud_target_matrix_json) }}
+
+    steps:
+      - name: Login to GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PACKAGES_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests/cloud-${{ matrix.target }}
+          pattern: digests-cloud-${{ matrix.target }}-linux-*
+          merge-multiple: true
+
+      # Cloud stages in place (no public/staging package split), so the
+      # pinned beta tag lands directly on the cloud package.
+      - name: Create beta manifest
+        env:
+          CLOUD_IMAGE: ${{ env.REGISTRY_GITHUB }}/${{ matrix.image }}
+          BETA_TAG: ${{ needs.prepare-release.outputs.beta_tag }}
+        run: |
+          mapfile -t DIGEST_FILES < <(find "/tmp/digests/cloud-${{ matrix.target }}" -type f -name '*.digest' | sort)
+
+          if [ "${#DIGEST_FILES[@]}" -eq 0 ]; then
+            echo "No digest artifacts found for cloud ${{ matrix.target }}" >&2
+            exit 1
+          fi
+
+          SOURCES=()
+          for digest_file in "${DIGEST_FILES[@]}"; do
+            digest="$(tr -d '\n' < "$digest_file")"
+            SOURCES+=("${CLOUD_IMAGE}@${digest}")
+          done
+
+          docker buildx imagetools create \
+            --tag "${CLOUD_IMAGE}:${BETA_TAG}" \
+            "${SOURCES[@]}"
+
+  sync-ecr:
+    needs: [prepare-release, merge-manifests-cloud]
+    if: needs.prepare-release.outputs.mode == 'release' && needs.merge-manifests-cloud.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Install skopeo
@@ -803,6 +876,7 @@ jobs:
         prepare-release,
         build-push-cloud,
         build-push-ee,
+        merge-manifests-cloud,
         merge-manifests-ee,
         merge-agent-manifest,
         sync-ecr,
@@ -817,9 +891,9 @@ jobs:
         run: |
           if [ "${{ needs.prepare-release.outputs.mode }}" != "release" ]; then
             echo "status=Rehearsal" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-cloud.result }}" == "cancelled" ] || [ "${{ needs.build-push-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ]; then
+          elif [ "${{ needs.build-push-cloud.result }}" == "cancelled" ] || [ "${{ needs.build-push-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-cloud.result }}" == "cancelled" ] || [ "${{ needs.merge-manifests-ee.result }}" == "cancelled" ] || [ "${{ needs.merge-agent-manifest.result }}" == "cancelled" ] || [ "${{ needs.sync-ecr.result }}" == "cancelled" ]; then
             echo "status=Cancelled" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build-push-cloud.result }}" == "success" ] && [ "${{ needs.build-push-ee.result }}" == "success" ] && [ "${{ needs.merge-manifests-ee.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ]; then
+          elif [ "${{ needs.build-push-cloud.result }}" == "success" ] && [ "${{ needs.build-push-ee.result }}" == "success" ] && [ "${{ needs.merge-manifests-cloud.result }}" == "success" ] && [ "${{ needs.merge-manifests-ee.result }}" == "success" ] && [ "${{ needs.merge-agent-manifest.result }}" == "success" ] && [ "${{ needs.sync-ecr.result }}" == "success" ]; then
             echo "status=Released" >> $GITHUB_OUTPUT
           else
             echo "status=Fail" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -521,14 +521,18 @@ jobs:
 
   # Cloud images are multi-arch (amd64 + arm64, native runners): each leg
   # pushes by digest and merge-manifests-cloud stitches the beta manifest,
-  # mirroring the EE flow. Edition-specific bits: CLOUD edition flag, Sentry
-  # sourcemap upload, CDN asset prefix, and the Next static asset upload
-  # config. Both legs keep IDENTICAL build args — including the sourcemap and
-  # asset uploads — because the frontend is compiled per-leg and content
-  # hashes are not guaranteed to match across arches: if only amd64 uploaded,
-  # an arm64 image whose chunks hashed differently would reference CDN assets
-  # that were never uploaded. Re-uploading is idempotent (content-hashed S3
-  # keys, checksum-deduped Sentry artifacts), so the duplicate is harmless.
+  # mirroring the EE flow.
+  #
+  # The arch variants under one tag deliberately DIFFER in how they serve the
+  # frontend: amd64 (CDN-fronted production) gets the CDN asset prefix plus
+  # Sentry sourcemap and static asset uploads; arm64 is a self-contained
+  # image (no prefix, no uploads — the Dockerfile defaults) for deployments
+  # that serve assets from the container. The split is load-bearing, not just
+  # thrift: next build has no pinned generateBuildId, so each leg emits its
+  # own buildId-scoped asset paths — an arm64 build that baked in the CDN
+  # prefix would reference paths only its own (skipped) upload could have
+  # provided. If arm64 ever needs to run behind the CDN, its leg must get
+  # the prefix AND all uploads together, never the prefix alone.
   # Deliberately NOT gated on ensure-agent-base: the cloud images don't
   # consume the agent base, and in the old two-workflow world a base failure
   # never stopped the cloud images from being built and pushed (only the
@@ -564,7 +568,7 @@ jobs:
         run: node ./scripts/generate-docker-contexts.mjs
 
       - name: Prepare upload assets config
-        if: matrix.file == 'Dockerfile'
+        if: matrix.file == 'Dockerfile' && matrix.platform == 'linux/amd64'
         id: upload_assets
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -641,8 +645,8 @@ jobs:
             SENTRY_ORG=${{ secrets.SENTRY_ORG }}
             SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-            SENTRY_SOURCEMAPS_UPLOAD=true
-            NEXT_BUILD_ENV_ASSET_PREFIX=${{ vars.NEXT_BUILD_ENV_ASSET_PREFIX }}
+            SENTRY_SOURCEMAPS_UPLOAD=${{ matrix.platform == 'linux/amd64' }}
+            NEXT_BUILD_ENV_ASSET_PREFIX=${{ matrix.platform == 'linux/amd64' && vars.NEXT_BUILD_ENV_ASSET_PREFIX || '' }}
             UPLOAD_ASSETS_LIST_B64=${{ steps.upload_assets.outputs.list_b64 }}
             BUILD_VERSION=${{ needs.prepare-release.outputs.release_id }}
             FRONTEND_RELEASE=${{ needs.prepare-release.outputs.release_id }}

--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -846,6 +846,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
+      # arm64 ships from ghcr ONLY. ECR deliberately receives just the amd64
+      # variant (a plain image manifest, not an index): the ECS fleet is
+      # amd64, and a single-arch ECR tag keeps the staging CDN patch's
+      # in-place tag overwrite (manual-ecs-staging-deploy) trivially safe —
+      # no multi-arch index for it to clobber.
       - name: Sync images to ECR
         env:
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
@@ -858,7 +863,7 @@ jobs:
           IMAGES=("teable-cloud" "teable-sandbox-cloud")
 
           for image in "${IMAGES[@]}"; do
-            skopeo copy --all \
+            skopeo copy --override-arch amd64 --override-os linux \
               --src-creds="$SRC_CREDS" \
               --dest-creds="AWS:${ECR_PASSWORD}" \
               "docker://${{ env.REGISTRY_GITHUB }}/${image}:${BETA_TAG}" \

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -142,9 +142,7 @@ jobs:
   # share the production bucket: keys are content-hashed per build so nothing
   # referenced by a released build is ever touched, and the upload is
   # append-only (never --delete). Images whose bundle format the script does
-  # not recognize are deployed untouched. Multi-arch: only the amd64 variant
-  # is patched (arm64 is the self-contained no-CDN variant) — the push step
-  # re-stitches the index so the arm64 leg survives the in-place update.
+  # not recognize are deployed untouched.
   patch-cdn:
     name: Patch staging image for CDN
     needs: prepare
@@ -266,37 +264,8 @@ jobs:
         if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
         run: |
           set -euo pipefail
-
-          # The staging tag is a multi-arch index: amd64 is the CDN-fronted
-          # variant this job patches; arm64 is the self-contained variant (no
-          # prefix baked, never patched — it serves assets from the
-          # container). A plain push of the runner-built amd64 image would
-          # clobber the index and strand arm64 consumers of the tag, so
-          # capture the arm64 digest first and stitch it back in.
-          ARM64_DIGEST=$(docker buildx imagetools inspect --raw "${ECR_IMAGE}:${STAGING_TAG}" \
-            | jq -r '[.manifests[]? | select(.platform.architecture=="arm64" and .platform.os=="linux")][0].digest // empty')
-
-          if [ -z "$ARM64_DIGEST" ]; then
-            # Single-arch tag from before the multi-arch split: overwrite in
-            # place, exactly the old behavior.
-            docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}"
-            docker push "${ECR_IMAGE}:${STAGING_TAG}"
-            exit 0
-          fi
-
-          # The patched amd64 needs a registry ref before imagetools can
-          # stitch it into an index. The helper tag is KEPT, not deleted: it
-          # pins the child manifest so an untagged-image cleanup can never
-          # hollow out the index, and its beta- prefix keeps it in the same
-          # cleanup channel as the tag it belongs to. Exact-match tag
-          # resolution in the deploy workflows never picks it up.
-          docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}-cdn-amd64"
-          docker push "${ECR_IMAGE}:${STAGING_TAG}-cdn-amd64"
-
-          docker buildx imagetools create \
-            --tag "${ECR_IMAGE}:${STAGING_TAG}" \
-            "${ECR_IMAGE}:${STAGING_TAG}-cdn-amd64" \
-            "${ECR_IMAGE}@${ARM64_DIGEST}"
+          docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}"
+          docker push "${ECR_IMAGE}:${STAGING_TAG}"
 
   deploy-sandbox:
     name: Deploy Sandbox to Staging ECS

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -142,7 +142,9 @@ jobs:
   # share the production bucket: keys are content-hashed per build so nothing
   # referenced by a released build is ever touched, and the upload is
   # append-only (never --delete). Images whose bundle format the script does
-  # not recognize are deployed untouched.
+  # not recognize are deployed untouched. Multi-arch: only the amd64 variant
+  # is patched (arm64 is the self-contained no-CDN variant) — the push step
+  # re-stitches the index so the arm64 leg survives the in-place update.
   patch-cdn:
     name: Patch staging image for CDN
     needs: prepare
@@ -264,8 +266,37 @@ jobs:
         if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
         run: |
           set -euo pipefail
-          docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}"
-          docker push "${ECR_IMAGE}:${STAGING_TAG}"
+
+          # The staging tag is a multi-arch index: amd64 is the CDN-fronted
+          # variant this job patches; arm64 is the self-contained variant (no
+          # prefix baked, never patched — it serves assets from the
+          # container). A plain push of the runner-built amd64 image would
+          # clobber the index and strand arm64 consumers of the tag, so
+          # capture the arm64 digest first and stitch it back in.
+          ARM64_DIGEST=$(docker buildx imagetools inspect --raw "${ECR_IMAGE}:${STAGING_TAG}" \
+            | jq -r '[.manifests[]? | select(.platform.architecture=="arm64" and .platform.os=="linux")][0].digest // empty')
+
+          if [ -z "$ARM64_DIGEST" ]; then
+            # Single-arch tag from before the multi-arch split: overwrite in
+            # place, exactly the old behavior.
+            docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}"
+            docker push "${ECR_IMAGE}:${STAGING_TAG}"
+            exit 0
+          fi
+
+          # The patched amd64 needs a registry ref before imagetools can
+          # stitch it into an index. The helper tag is KEPT, not deleted: it
+          # pins the child manifest so an untagged-image cleanup can never
+          # hollow out the index, and its beta- prefix keeps it in the same
+          # cleanup channel as the tag it belongs to. Exact-match tag
+          # resolution in the deploy workflows never picks it up.
+          docker tag app-cdn-variant "${ECR_IMAGE}:${STAGING_TAG}-cdn-amd64"
+          docker push "${ECR_IMAGE}:${STAGING_TAG}-cdn-amd64"
+
+          docker buildx imagetools create \
+            --tag "${ECR_IMAGE}:${STAGING_TAG}" \
+            "${ECR_IMAGE}:${STAGING_TAG}-cdn-amd64" \
+            "${ECR_IMAGE}@${ARM64_DIGEST}"
 
   deploy-sandbox:
     name: Deploy Sandbox to Staging ECS

--- a/.github/workflows/sync-aliyun.yaml
+++ b/.github/workflows/sync-aliyun.yaml
@@ -73,6 +73,9 @@ jobs:
           FAILED=0
 
           if [ "${{ inputs.edition }}" = "cloud" ]; then
+            # The cloud app images are multi-arch on ghcr, but arm64 ships
+            # from ghcr ONLY — Aliyun (like ECR) stays amd64-only, byte-
+            # identical to the pre-multi-arch behavior.
             IMAGES=("teable-cloud" "teable-sandbox-cloud")
             for image in "${IMAGES[@]}"; do
               for tag in "${TAGS[@]}"; do
@@ -80,7 +83,7 @@ jobs:
                 retry_copy \
                   "${SRC_REGISTRY}/${image}:${tag}" \
                   "${DST_REGISTRY}/${image}:${tag}" \
-                  "--all" \
+                  "--override-arch amd64 --override-os linux" \
                   || FAILED=1
               done
             done


### PR DESCRIPTION
## Summary
- Add a native-runner `linux/arm64` leg to the cloud build matrix (`teable-cloud`, `teable-sandbox-cloud`) — same `ubuntu-24.04-arm` runners the EE lane already uses, so wall-clock stays roughly flat and the existing `deps-*-linux-arm64` cache is reused as-is.
- Switch `build-push-cloud` from direct tag push to push-by-digest, with digest artifacts prefixed `digests-cloud-*` to stay clear of the EE merge's download pattern.
- New `merge-manifests-cloud` job stitches the multi-arch manifest onto the ghcr `beta-*` tag, mirroring `merge-manifests-ee`; it runs in rehearsal mode too, matching the old direct-push behavior. `verify-cdn-patchability` now gates on it (the beta tag only exists after the stitch).
- `merge-manifests-cloud` joins the unified `determine-status` gate — no partial-success states.

## Distribution model: arm64 ships from ghcr ONLY
- **ghcr**: multi-arch `beta-*` (and, at launch, `release.*`) — arm64 consumers pull from here. ghcr is never patched; it stays the authoritative unpatched artifact.
- **ECR & Aliyun**: deliberately amd64-only (`skopeo --override-arch amd64`, plain image manifest, no index) — byte-identical to the pre-multi-arch behavior. The ECS fleet is amd64, and a single-arch ECR tag keeps the staging CDN patch's in-place tag overwrite (`manual-ecs-staging-deploy`) trivially safe with no index to clobber.

## The arch variants deliberately differ in frontend serving
- **amd64** (CDN-fronted production): CDN asset prefix + Sentry sourcemap upload + static asset upload, exactly as before.
- **arm64**: self-contained — no asset prefix, no uploads, no Sentry (the Dockerfile defaults, the same path every EE build already exercises). Its deployments serve assets from the container.

The split is load-bearing: `next build` has no pinned `generateBuildId`, so each leg emits its own buildId-scoped asset paths. An arm64 image that baked in the CDN prefix would reference paths only its own (skipped) upload could have provided. If arm64 ever needs to run behind the CDN, its leg must get the prefix AND all uploads together, never the prefix alone.

## Test plan
- [x] YAML parses; matrix JSON validated
- [x] Empty-upload build path already proven by every EE build (same Dockerfile defaults)
- [ ] `workflow_dispatch` with `mode=rehearsal` — builds both arches and pushes only the pinned ghcr `beta-*` tag, exercising the new digest/merge path end-to-end without touching ECR sync or tracking
- [ ] `docker buildx imagetools inspect ghcr.io/teableio/teable-cloud:beta-<id>` shows both `linux/amd64` and `linux/arm64`
- [ ] After a release-mode run: ECR `beta-<id>` is a plain amd64 manifest (not an index)
- [ ] Run the arm64 variant from ghcr without CDN and confirm `_next/static` assets are served from the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)