### PR TITLE
ci: patch launches for the CDN; remove build-time asset uploads

### DIFF
--- a/.github/workflows/build-teable.yaml
+++ b/.github/workflows/build-teable.yaml
@@ -567,34 +567,9 @@ jobs:
         if: matrix.file == 'Dockerfile'
         run: node ./scripts/generate-docker-contexts.mjs
 
-      # No Sealos (CN) upload here: that bucket is owned by the CN deploy's
-      # patch-cdn job — build-time uploads overwrite patched same-name chunks
-      # (the 2026-07-23 staging incident). The S3 upload below has the same
-      # hazard and is slated for removal.
-      - name: Prepare upload assets config
-        if: matrix.file == 'Dockerfile' && matrix.platform == 'linux/amd64'
-        id: upload_assets
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          node <<'EOF'
-          const fs = require('node:fs');
-
-          const uploadAssetsList = [
-            [
-              'aws-objectstorage',
-              'https://s3.us-west-2.amazonaws.com',
-              process.env.AWS_ACCESS_KEY_ID,
-              process.env.AWS_SECRET_ACCESS_KEY,
-              'teable-next-asset',
-            ],
-          ];
-
-          const encoded = Buffer.from(JSON.stringify(uploadAssetsList)).toString('base64');
-          process.stdout.write(`::add-mask::${encoded}\n`);
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `list_b64=${encoded}\n`);
-          EOF
+      # No build-time asset uploads: both CDN buckets are owned by the deploy
+      # patch-cdn jobs. Build-time uploads overwrite patched same-name chunks
+      # (the 2026-07-23 staging incident).
 
       # Freeing disk costs 1-4 min of pure rm -rf (measured variance); run it
       # in the background so it overlaps the buildx setup and cache import
@@ -642,7 +617,6 @@ jobs:
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_SOURCEMAPS_UPLOAD=${{ matrix.platform == 'linux/amd64' }}
             NEXT_BUILD_ENV_ASSET_PREFIX=${{ matrix.platform == 'linux/amd64' && vars.NEXT_BUILD_ENV_ASSET_PREFIX || '' }}
-            UPLOAD_ASSETS_LIST_B64=${{ steps.upload_assets.outputs.list_b64 }}
             BUILD_VERSION=${{ needs.prepare-release.outputs.release_id }}
             FRONTEND_RELEASE=${{ needs.prepare-release.outputs.release_id }}
             GIT_COMMIT_SHA=${{ needs.prepare-release.outputs.source_sha }}

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -191,6 +191,130 @@ jobs:
             done
           done
 
+  # Production twin of the staging patch-cdn. Prefers promoting the staging-
+  # patched beta (ship what staging tested; its assets are already in S3);
+  # otherwise patches the clean release stamp in place. ghcr stays clean —
+  # sync-aliyun keeps shipping unpatched images to CN, which patches its own.
+  patch-cdn:
+    name: Patch app image for CDN
+    needs: [prepare, stamp-release]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_ID: ${{ inputs.image_tag }}
+      CDN_ORIGIN: https://sss.teable.ai
+      ASSET_BUCKET: teable-next-asset
+      ECR_IMAGE: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Login to AWS ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Check if the release is already patched (rollback fast-path)
+        id: existing
+        run: |
+          set -euo pipefail
+          docker pull "${ECR_IMAGE}:${RELEASE_ID}"
+          CURRENT=$(docker inspect --format '{{index .Config.Labels "teable.asset-prefix"}}' \
+            "${ECR_IMAGE}:${RELEASE_ID}" 2>/dev/null || echo "")
+          if [ "$CURRENT" = "$CDN_ORIGIN" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "✅ ${RELEASE_ID} already carries the ${CDN_ORIGIN} patch; skipping"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Promote the staging-patched beta if available
+        if: steps.existing.outputs.exists == 'false'
+        id: promote
+        run: |
+          set -euo pipefail
+          BETA_TAG="beta-${RELEASE_ID#release.}"
+          if docker pull "${ECR_IMAGE}:${BETA_TAG}" 2>/dev/null; then
+            LABEL=$(docker inspect --format '{{index .Config.Labels "teable.asset-prefix"}}' \
+              "${ECR_IMAGE}:${BETA_TAG}" 2>/dev/null || echo "")
+            if [ "$LABEL" = "$CDN_ORIGIN" ]; then
+              docker tag "${ECR_IMAGE}:${BETA_TAG}" "${ECR_IMAGE}:${RELEASE_ID}"
+              docker push "${ECR_IMAGE}:${RELEASE_ID}"
+              echo "promoted=true" >> "$GITHUB_OUTPUT"
+              echo "✅ promoted staging-patched ${BETA_TAG} (assets already uploaded by staging)"
+              exit 0
+            fi
+          fi
+          echo "promoted=false" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout deploy scripts
+        if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false'
+        uses: actions/checkout@v4
+
+      - name: Build patch layer
+        if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false'
+        id: patch
+        run: |
+          set -euo pipefail
+
+          # Unrecognized bundle format → launch untouched, don't block.
+          if ! docker run --rm --entrypoint node -e PATCH_DRY_RUN=1 \
+              -v "$PWD/.github/scripts/patch-asset-prefix.mjs:/tmp/patch-asset-prefix.mjs:ro" \
+              "${ECR_IMAGE}:${RELEASE_ID}" /tmp/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app; then
+            echo "::warning::${RELEASE_ID} bundle format not recognized by the patch script; launching untouched"
+            echo "patched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          docker build -t app-cdn-variant \
+            --build-arg BASE_IMAGE="${ECR_IMAGE}:${RELEASE_ID}" \
+            --build-arg CDN_ORIGIN="${CDN_ORIGIN}" \
+            -f - .github/scripts <<'EOF'
+          ARG BASE_IMAGE
+          FROM ${BASE_IMAGE}
+          ARG CDN_ORIGIN
+          RUN --mount=type=bind,source=patch-asset-prefix.mjs,target=/tmp/patch-asset-prefix.mjs \
+              node /tmp/patch-asset-prefix.mjs "${CDN_ORIGIN}" /app
+          ENV NEXT_BUILD_ENV_ASSET_PREFIX=${CDN_ORIGIN}
+          LABEL teable.asset-prefix=${CDN_ORIGIN}
+          EOF
+          echo "patched=true" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-check the patched image
+        if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh app-cdn-variant -c '
+            set -e
+            SAMPLE=$(ls /app/enterprise/app-ee/.next/static/chunks/turbopack-*.js | head -1)
+            grep -q "'"${CDN_ORIGIN}"'/_next/" "$SAMPLE"
+            [ "$NEXT_BUILD_ENV_ASSET_PREFIX" = "'"${CDN_ORIGIN}"'" ]
+            echo "smoke OK: $SAMPLE"
+          '
+
+      - name: Upload patched static assets to S3 (append-only)
+        if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          CID=$(docker create app-cdn-variant)
+          docker cp "$CID:/app/enterprise/app-ee/.next/static" ./static-out
+          docker rm "$CID" >/dev/null
+          # NEVER --delete: chunks of other builds must survive.
+          # Fonts land as octet-stream (CLI can't guess those extensions) —
+          # accepted: browsers sniff font magic bytes, nothing breaks.
+          aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
+            --recursive --only-show-errors
+          echo "uploaded $(find ./static-out -type f | wc -l) files"
+
+      - name: Push patched image under the release tag
+        if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false' && steps.patch.outputs.patched == 'true'
+        run: |
+          set -euo pipefail
+          docker tag app-cdn-variant "${ECR_IMAGE}:${RELEASE_ID}"
+          docker push "${ECR_IMAGE}:${RELEASE_ID}"
+
   deploy-sandbox:
     name: Deploy Sandbox to ECS
     needs: [prepare, stamp-release]
@@ -236,9 +360,9 @@ jobs:
 
   deploy-app:
     name: Deploy Main to ECS
-    # stamp-release must have produced the release.<id> tag before the
-    # migration one-off task or the service tries to pull it.
-    needs: [prepare, stamp-release]
+    # patch-cdn must have finalized the release.<id> tag (and its assets)
+    # before the migration one-off task or the service pulls it.
+    needs: [prepare, stamp-release, patch-cdn]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -151,7 +151,6 @@ jobs:
       STAGING_TAG: ${{ needs.prepare.outputs.staging_tag }}
       CDN_ORIGIN: https://sss.teable.ai
       ASSET_BUCKET: teable-next-asset
-      CLOUDFRONT_DISTRIBUTION_ID: E3PW5TFEINWLOJ
       ECR_IMAGE: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud
 
     steps:
@@ -246,19 +245,6 @@ jobs:
           aws s3 cp ./static-out "s3://${ASSET_BUCKET}/_next/static/" \
             --recursive --only-show-errors
           echo "uploaded $(find ./static-out -type f | wc -l) files"
-
-      - name: Invalidate CloudFront runtime chunks
-        if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'
-        run: |
-          # Edges only cache what was requested; pre-deploy these URLs are
-          # unreferenced, so this matters only if someone fetched them
-          # manually before the patch (a debug curl poisons the edge for up
-          # to the TTL — hydration silently dies). Fire and forget: the ECS
-          # deploy takes far longer than invalidation propagation.
-          aws cloudfront create-invalidation \
-            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
-            --paths "/_next/static/chunks/turbopack-*" \
-            --query 'Invalidation.Id' --output text
 
       - name: Push patched image back under the same staging tag
         if: steps.existing.outputs.exists == 'false' && steps.patch.outputs.patched == 'true'


### PR DESCRIPTION
## What

**manual-ecs-deploy.yml** (+130) — new `patch-cdn` job between `stamp-release` and `deploy-app`, three branches:
1. ECR `release.<id>` already patched (rollback/re-launch) → skip everything
2. ECR `beta-<id>` carries the staging patch → **promote by re-tag** — production ships the exact bits staging validated; assets already in S3 (~2 min, the normal path)
3. Neither (hotfix launch / reaped beta) → patch the clean stamp in place: dry-run → patch → smoke → upload S3 → push; unrecognized bundle formats launch untouched

Tag references unchanged; `promote-latest`/`sync-aliyun`/`cleanup-beta` untouched (ECR latest picks up the patched stamp via ordering, ghcr stays clean for CN).

**build-teable.yaml** (−32) — build-time S3 asset upload removed (Sealos went in #80). Both buckets are now written exclusively by patch jobs. This kills the recurring staging poison window at the root: every develop merge used to overwrite patched same-name runtime chunks with unpatched ones for 5–15 min (the 2026-07-23 hydration incident).

**manual-ecs-staging-deploy.yml** (−14) — CloudFront invalidation steps removed from both deploy flows: with no unpatched content ever reachable via CDN, they lost their threat model (same-name chunks patch to identical bytes; 404s negative-cache for ~10 s).

## Notes

- First launch after merge takes branch 2 for any staging-tested build — a pure re-tag, minimal-risk cutover for teable.ai.
- `NEXT_BUILD_ENV_ASSET_PREFIX` build-arg (re-added by #79) is left in place but must stay empty: a build-time prefix would make the runtime chunks unrecognizable to the patch script. Recommend deleting the disabled `_X_NEXT_BUILD_ENV_ASSET_PREFIX` var to prevent accidental re-enabling.
- `upload-assets.mjs` in teable-ee now no-ops (verified: empty list → skip, exit 0); removing it and the Dockerfile upload stage is follow-up hygiene.