### PR TITLE
ci: serialize staging deploys (Codex P1 on #82)

### DIFF
--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -81,6 +81,14 @@ on:
       TEABLE_API_TOKEN:
         required: false
 
+# Serialize staging deploys (Codex review on #82): without this, an older
+# run finishing late could roll the shared EKS deployments back to an older
+# digest after a newer run already completed. Queue, never cancel: every
+# triggered build still deploys, strictly in order.
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false
+
 jobs:
   prepare:
     name: Prepare Deployment


### PR DESCRIPTION
Codex review P1：无 concurrency 组时，重叠的两次发布可能让旧 run 后到、把共享的 EKS Deployment 滚回旧 digest。加 workflow 级 concurrency（queue、不取消），所有发布严格按序执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)