### PR TITLE
ci: 生产发布加 EKS 双跑腿（权重 0，正式切换即切流量）

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -115,6 +115,12 @@ on:
       INFRA_TEABLE_CN_PREHEAT_TOKEN:
         required: false
 
+# Serialize production deploys (same rationale as staging, Codex P1 on #82):
+# an older run finishing late must not roll the shared EKS deployments back.
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
 jobs:
   prepare:
     name: Prepare Deployment
@@ -510,6 +516,81 @@ jobs:
           WORKER_SERVICE: teable-byodb-migration-worker
           WORKER_OTEL_SERVICE_NAME: teable-ai-byodb-migration-worker
         run: .github/scripts/ensure-byodb-migration-worker-ecs.sh
+
+  # Dual-run phase (since 2026-07-27): production deploys land BOTH on ECS
+  # (live traffic) and on teable-infra EKS (attached to teable-alb at weight
+  # 0). A failure here marks the run red so drift is visible, but does NOT
+  # gate promote-latest / sync-aliyun — the EKS side serves no traffic yet.
+  # At formal cutover, fold this job into the notify/promote gating.
+  #
+  # Deploys by DIGEST: patch-cdn rewrites the release tag in place, so a tag
+  # reference neither triggers rollouts on redeploys nor survives node image
+  # caches.
+  deploy-eks:
+    name: Deploy to Production EKS (dual-run, weight 0)
+    needs: [prepare, deploy-app, deploy-sandbox]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials (OIDC, namespace-scoped role)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::649941507946:role/teable-staging-eks-deploy
+          aws-region: us-west-2
+
+      - name: Roll EKS deployments to this release
+        env:
+          RELEASE_ID: ${{ inputs.image_tag }}
+          ECR: 649941507946.dkr.ecr.us-west-2.amazonaws.com
+        run: |
+          set -euo pipefail
+          aws eks update-kubeconfig --region us-west-2 --name teable-infra
+
+          APP_DIGEST=$(aws ecr describe-images --region us-west-2 \
+            --repository-name teable/teable-cloud \
+            --image-ids imageTag="$RELEASE_ID" \
+            --query 'imageDetails[0].imageDigest' --output text)
+          SANDBOX_DIGEST=$(aws ecr describe-images --region us-west-2 \
+            --repository-name teable/teable-sandbox-cloud \
+            --image-ids imageTag="$RELEASE_ID" \
+            --query 'imageDetails[0].imageDigest' --output text)
+          echo "app:     ${RELEASE_ID} -> ${APP_DIGEST}"
+          echo "sandbox: ${RELEASE_ID} -> ${SANDBOX_DIGEST}"
+
+          kubectl -n teable-prod set image deploy/teable-prod \
+            teable="${ECR}/teable/teable-cloud@${APP_DIGEST}"
+          kubectl -n teable-prod set image deploy/teable-prod-byodb-worker \
+            teable="${ECR}/teable/teable-cloud@${APP_DIGEST}"
+          kubectl -n teable-prod set image deploy/teable-sandbox \
+            sandbox="${ECR}/teable/teable-sandbox-cloud@${SANDBOX_DIGEST}"
+
+      - name: Wait for rollouts
+        run: |
+          set -euo pipefail
+          kubectl -n teable-prod rollout status deploy/teable-prod --timeout=600s
+          kubectl -n teable-prod rollout status deploy/teable-prod-byodb-worker --timeout=300s
+          kubectl -n teable-prod rollout status deploy/teable-sandbox --timeout=300s
+
+      - name: Verify ALB target health (weight-0 passive check)
+        run: |
+          set -euo pipefail
+          for tg_name in teable-eks-app teable-eks-socket; do
+            TG_ARN=$(aws elbv2 describe-target-groups --region us-west-2 \
+              --names "$tg_name" --query 'TargetGroups[0].TargetGroupArn' --output text)
+            for i in $(seq 1 20); do
+              STATES=$(aws elbv2 describe-target-health --region us-west-2 \
+                --target-group-arn "$TG_ARN" \
+                --query 'TargetHealthDescriptions[].TargetHealth.State' --output text)
+              TOTAL=$(echo $STATES | wc -w); HEALTHY=$(echo $STATES | tr ' ' '\n' | grep -c healthy || true)
+              echo "$tg_name: $HEALTHY/$TOTAL healthy"
+              [ "$TOTAL" -gt 0 ] && [ "$HEALTHY" = "$TOTAL" ] && break
+              [ "$i" = "20" ] && echo "::error::$tg_name targets not healthy" && exit 1
+              sleep 10
+            done
+          done
 
   promote-latest:
     name: Promote Release Tag to Latest


### PR DESCRIPTION
双跑模式（2026-07-27 拍板）：生产发布同时落 ECS（承载真实流量）与 teable-infra EKS（挂 teable-alb 权重 0）。正式切换日只动监听器权重。

- deploy-eks 按 **digest** 滚动 teable-prod / teable-prod-byodb-worker / teable-sandbox（patch-cdn 会原地改写 release tag）
- 被动侧冒烟 = 两个权重 0 的 TG（teable-eks-app / teable-eks-socket）达到 healthy
- 失败标红可见，但**不阻塞** promote-latest / sync-aliyun——EKS 侧尚无流量，无资格拦发布；切换时再并入 notify 门禁
- 复用 staging 的 OIDC 角色，access entry 已扩为 namespace 级 [teable-staging, teable-prod]；加 prod-deploy concurrency 组

配套的 k8s 资源（ns teable-prod 三件套 + TG + TargetGroupBinding + 监听器 100/0 权重）随本 PR 合并后由基础设施侧就位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)