### PR TITLE
ci: EKS 双跑腿修复（#84 事后 Codex 评审的 4 项）

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -556,19 +556,25 @@ jobs:
           set -euo pipefail
           aws eks update-kubeconfig --region us-west-2 --name teable-infra
 
-          # Ordering guard (replaces workflow-level concurrency): a deploy
-          # attempt that STARTED later wins. If the deployments already carry
-          # a newer deploy-epoch, this older attempt steps aside instead of
-          # rolling them back. Rollbacks still work: a rollback run starts
-          # later, so its epoch is higher.
-          EPOCH=$(date +%s)
-          CUR=$(kubectl -n teable-prod get deploy teable-prod \
-            -o jsonpath='{.metadata.annotations.teable\.io/deploy-epoch}' 2>/dev/null || echo "")
-          if [ -n "$CUR" ] && [ "$CUR" -gt "$EPOCH" ]; then
-            echo "::notice::newer deploy-epoch $CUR already applied (mine: $EPOCH); skipping EKS roll"
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Ordering guard (Codex on #85): token is the RUN id — assigned at
+          # run creation, so a run delayed in patch-cdn/migration still keeps
+          # its original order (run ids increase monotonically per repo, and
+          # workflow_call shares the caller's run id). Annotation write is a
+          # CAS via resourceVersion; the primary deploy acts as the lock.
+          MY_ID=${{ github.run_id }}
+          for attempt in 1 2 3 4 5; do
+            read -r RV CUR <<<"$(kubectl -n teable-prod get deploy teable-prod \
+              -o jsonpath='{.metadata.resourceVersion} {.metadata.annotations.teable\.io/deploy-run-id}')"
+            if [ -n "$CUR" ] && [ "$CUR" -ge "$MY_ID" ] 2>/dev/null; then
+              echo "::notice::run $CUR (>= mine $MY_ID) already deployed EKS; skipping"
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            kubectl -n teable-prod annotate --overwrite --resource-version="$RV" \
+              deploy/teable-prod teable.io/deploy-run-id="$MY_ID" 2>/dev/null && break
+            [ "$attempt" = "5" ] && echo "::error::deploy-run-id CAS failed 5x" && exit 1
+            sleep 2
+          done
 
           APP_DIGEST=$(aws ecr describe-images --region us-west-2 \
             --repository-name teable/teable-cloud \
@@ -589,8 +595,17 @@ jobs:
             sandbox="${ECR}/teable/teable-sandbox-cloud@${SANDBOX_DIGEST}"
 
           kubectl -n teable-prod annotate --overwrite \
-            deploy/teable-prod deploy/teable-prod-byodb-worker deploy/teable-sandbox \
-            teable.io/deploy-epoch="$EPOCH" teable.io/deploy-release="$RELEASE_ID"
+            deploy/teable-prod-byodb-worker deploy/teable-sandbox \
+            teable.io/deploy-run-id="$MY_ID" teable.io/deploy-release="$RELEASE_ID"
+          kubectl -n teable-prod annotate --overwrite \
+            deploy/teable-prod teable.io/deploy-release="$RELEASE_ID"
+
+          # Post-mutation check: if a newer run took the lock mid-flight the
+          # images may interleave — surface it instead of pretending order.
+          FINAL=$(kubectl -n teable-prod get deploy teable-prod \
+            -o jsonpath='{.metadata.annotations.teable\.io/deploy-run-id}')
+          [ "$FINAL" != "$MY_ID" ] && echo "::warning::run $FINAL overlapped this deploy; verify EKS image versions"
+          true
 
       - name: Wait for rollouts
         if: steps.roll.outputs.skipped != 'true'
@@ -614,11 +629,10 @@ jobs:
               STATES=$(aws elbv2 describe-target-health --region us-west-2 \
                 --target-group-arn "$TG_ARN" \
                 --query 'TargetHealthDescriptions[].TargetHealth.State' --output text | tr '\t' '\n')
-              HEALTHY=$(echo "$STATES" | grep -c '^healthy' || true)
-              INITIAL=$(echo "$STATES" | grep -c '^initial' || true)
-              UNHEALTHY=$(echo "$STATES" | grep -c '^unhealthy' || true)
-              echo "$tg_name: healthy=$HEALTHY initial=$INITIAL unhealthy=$UNHEALTHY (draining ignored)"
-              [ "$HEALTHY" -ge 1 ] && [ "$INITIAL" = "0" ] && [ "$UNHEALTHY" = "0" ] && break
+              HEALTHY=$(echo "$STATES" | awk '/^healthy/{c++} END{print c+0}')
+              NOTOK=$(echo "$STATES" | awk 'NF && $0 !~ /^healthy/ && $0 !~ /^draining/ {c++} END{print c+0}')
+              echo "$tg_name: healthy=$HEALTHY not-ok=$NOTOK (draining ignored)"
+              [ "$HEALTHY" -ge 1 ] && [ "$NOTOK" = "0" ] && break
               [ "$i" = "30" ] && echo "::error::$tg_name targets not settled healthy" && exit 1
               sleep 10
             done
@@ -629,11 +643,15 @@ jobs:
         env:
           RELEASE_ID: ${{ inputs.image_tag }}
         run: |
-          curl -s -X POST \
+          PAYLOAD=$(jq -n --arg t "⚠️ 生产 EKS 双跑腿失败（不阻塞发布链）: ${RELEASE_ID}
+run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{msg_type:"text",content:{text:$t}}')
+          HTTP=$(curl -s -o /tmp/feishu.out -w "%{http_code}" -X POST \
             'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
-            -H 'Content-Type: application/json' \
-            -d "$(printf '{"msg_type":"text","content":{"text":"⚠️ 生产 EKS 双跑腿失败（不阻塞发布链）: %s\nrun: %s"}}' \
-              "$RELEASE_ID" "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}")" || true
+            -H 'Content-Type: application/json' -d "$PAYLOAD")
+          if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
+            echo "::warning::Feishu alert failed HTTP $HTTP: $(cat /tmp/feishu.out)"
+          fi
 
   promote-latest:
     name: Promote Release Tag to Latest

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -565,11 +565,13 @@ jobs:
           for attempt in 1 2 3 4 5; do
             read -r RV CUR <<<"$(kubectl -n teable-prod get deploy teable-prod \
               -o jsonpath='{.metadata.resourceVersion} {.metadata.annotations.teable\.io/deploy-run-id}')"
-            if [ -n "$CUR" ] && [ "$CUR" -ge "$MY_ID" ] 2>/dev/null; then
-              echo "::notice::run $CUR (>= mine $MY_ID) already deployed EKS; skipping"
+            if [ -n "$CUR" ] && [ "$CUR" -gt "$MY_ID" ] 2>/dev/null; then
+              echo "::notice::run $CUR (> mine $MY_ID) already deployed EKS; skipping"
               echo "skipped=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            # rerun of the same run keeps its run_id — resume, don't skip
+            [ "$CUR" = "$MY_ID" ] && echo "resuming own run $MY_ID" && break
             kubectl -n teable-prod annotate --overwrite --resource-version="$RV" \
               deploy/teable-prod teable.io/deploy-run-id="$MY_ID" 2>/dev/null && break
             [ "$attempt" = "5" ] && echo "::error::deploy-run-id CAS failed 5x" && exit 1
@@ -604,8 +606,10 @@ jobs:
           # images may interleave — surface it instead of pretending order.
           FINAL=$(kubectl -n teable-prod get deploy teable-prod \
             -o jsonpath='{.metadata.annotations.teable\.io/deploy-run-id}')
-          [ "$FINAL" != "$MY_ID" ] && echo "::warning::run $FINAL overlapped this deploy; verify EKS image versions"
-          true
+          if [ "$FINAL" != "$MY_ID" ]; then
+            echo "::error::run $FINAL overlapped this deploy — EKS may hold mixed images; redeploy the latest release"
+            exit 1
+          fi
 
       - name: Wait for rollouts
         if: steps.roll.outputs.skipped != 'true'

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -643,9 +643,10 @@ jobs:
         env:
           RELEASE_ID: ${{ inputs.image_tag }}
         run: |
-          PAYLOAD=$(jq -n --arg t "⚠️ 生产 EKS 双跑腿失败（不阻塞发布链）: ${RELEASE_ID}
-run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            '{msg_type:"text",content:{text:$t}}')
+          PAYLOAD=$(jq -n \
+            --arg l1 "⚠️ 生产 EKS 双跑腿失败（不阻塞发布链）: ${RELEASE_ID}" \
+            --arg l2 "run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{msg_type:"text",content:{text:($l1 + "\n" + $l2)}}')
           HTTP=$(curl -s -o /tmp/feishu.out -w "%{http_code}" -X POST \
             'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
             -H 'Content-Type: application/json' -d "$PAYLOAD")

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -115,12 +115,12 @@ on:
       INFRA_TEABLE_CN_PREHEAT_TOKEN:
         required: false
 
-# Serialize production deploys (same rationale as staging, Codex P1 on #82):
-# an older run finishing late must not roll the shared EKS deployments back.
-concurrency:
-  group: prod-deploy
-  cancel-in-progress: false
-
+# NOTE on ordering: no workflow-level concurrency here on purpose — GitHub
+# keeps only ONE pending run per group and CANCELS earlier pending ones,
+# which would cancel a whole production release (ECS + promote + aliyun).
+# The only shared mutable state this workflow touches cross-run is the EKS
+# deployments; deploy-eks guards those with a deploy-epoch annotation CAS
+# instead (older attempt refuses to overwrite a newer one).
 jobs:
   prepare:
     name: Prepare Deployment
@@ -530,6 +530,11 @@ jobs:
     name: Deploy to Production EKS (dual-run, weight 0)
     needs: [prepare, deploy-app, deploy-sandbox]
     runs-on: ubuntu-latest
+    # Passive side must not fail the run: rollback-launch and any caller
+    # keying off this workflow's conclusion would otherwise skip their own
+    # bookkeeping when only the weight-0 EKS side hiccups. Visibility comes
+    # from the Feishu alert step below, not from a red run.
+    continue-on-error: true
     permissions:
       id-token: write
       contents: read
@@ -539,15 +544,31 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::649941507946:role/teable-staging-eks-deploy
+          role-session-name: eks-prod-dual-run
           aws-region: us-west-2
 
       - name: Roll EKS deployments to this release
+        id: roll
         env:
           RELEASE_ID: ${{ inputs.image_tag }}
           ECR: 649941507946.dkr.ecr.us-west-2.amazonaws.com
         run: |
           set -euo pipefail
           aws eks update-kubeconfig --region us-west-2 --name teable-infra
+
+          # Ordering guard (replaces workflow-level concurrency): a deploy
+          # attempt that STARTED later wins. If the deployments already carry
+          # a newer deploy-epoch, this older attempt steps aside instead of
+          # rolling them back. Rollbacks still work: a rollback run starts
+          # later, so its epoch is higher.
+          EPOCH=$(date +%s)
+          CUR=$(kubectl -n teable-prod get deploy teable-prod \
+            -o jsonpath='{.metadata.annotations.teable\.io/deploy-epoch}' 2>/dev/null || echo "")
+          if [ -n "$CUR" ] && [ "$CUR" -gt "$EPOCH" ]; then
+            echo "::notice::newer deploy-epoch $CUR already applied (mine: $EPOCH); skipping EKS roll"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           APP_DIGEST=$(aws ecr describe-images --region us-west-2 \
             --repository-name teable/teable-cloud \
@@ -567,7 +588,12 @@ jobs:
           kubectl -n teable-prod set image deploy/teable-sandbox \
             sandbox="${ECR}/teable/teable-sandbox-cloud@${SANDBOX_DIGEST}"
 
+          kubectl -n teable-prod annotate --overwrite \
+            deploy/teable-prod deploy/teable-prod-byodb-worker deploy/teable-sandbox \
+            teable.io/deploy-epoch="$EPOCH" teable.io/deploy-release="$RELEASE_ID"
+
       - name: Wait for rollouts
+        if: steps.roll.outputs.skipped != 'true'
         run: |
           set -euo pipefail
           kubectl -n teable-prod rollout status deploy/teable-prod --timeout=600s
@@ -575,22 +601,39 @@ jobs:
           kubectl -n teable-prod rollout status deploy/teable-sandbox --timeout=300s
 
       - name: Verify ALB target health (weight-0 passive check)
+        if: steps.roll.outputs.skipped != 'true'
         run: |
           set -euo pipefail
+          # draining targets are old pods on their way out (socket TG holds
+          # them up to 300s) — they must not fail the check. Settled means:
+          # at least one healthy, nothing still initializing or unhealthy.
           for tg_name in teable-eks-app teable-eks-socket; do
             TG_ARN=$(aws elbv2 describe-target-groups --region us-west-2 \
               --names "$tg_name" --query 'TargetGroups[0].TargetGroupArn' --output text)
-            for i in $(seq 1 20); do
+            for i in $(seq 1 30); do
               STATES=$(aws elbv2 describe-target-health --region us-west-2 \
                 --target-group-arn "$TG_ARN" \
-                --query 'TargetHealthDescriptions[].TargetHealth.State' --output text)
-              TOTAL=$(echo $STATES | wc -w); HEALTHY=$(echo $STATES | tr ' ' '\n' | grep -c healthy || true)
-              echo "$tg_name: $HEALTHY/$TOTAL healthy"
-              [ "$TOTAL" -gt 0 ] && [ "$HEALTHY" = "$TOTAL" ] && break
-              [ "$i" = "20" ] && echo "::error::$tg_name targets not healthy" && exit 1
+                --query 'TargetHealthDescriptions[].TargetHealth.State' --output text | tr '\t' '\n')
+              HEALTHY=$(echo "$STATES" | grep -c '^healthy' || true)
+              INITIAL=$(echo "$STATES" | grep -c '^initial' || true)
+              UNHEALTHY=$(echo "$STATES" | grep -c '^unhealthy' || true)
+              echo "$tg_name: healthy=$HEALTHY initial=$INITIAL unhealthy=$UNHEALTHY (draining ignored)"
+              [ "$HEALTHY" -ge 1 ] && [ "$INITIAL" = "0" ] && [ "$UNHEALTHY" = "0" ] && break
+              [ "$i" = "30" ] && echo "::error::$tg_name targets not settled healthy" && exit 1
               sleep 10
             done
           done
+
+      - name: Alert Feishu on EKS leg failure (run stays green)
+        if: failure()
+        env:
+          RELEASE_ID: ${{ inputs.image_tag }}
+        run: |
+          curl -s -X POST \
+            'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
+            -H 'Content-Type: application/json' \
+            -d "$(printf '{"msg_type":"text","content":{"text":"⚠️ 生产 EKS 双跑腿失败（不阻塞发布链）: %s\nrun: %s"}}' \
+              "$RELEASE_ID" "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}")" || true
 
   promote-latest:
     name: Promote Release Tag to Latest

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -451,6 +451,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Roll EKS deployments to this build
+        id: roll
         env:
           STAGING_TAG: ${{ needs.prepare.outputs.staging_tag }}
           ECR: 649941507946.dkr.ecr.us-west-2.amazonaws.com
@@ -458,15 +459,22 @@ jobs:
           set -euo pipefail
           aws eks update-kubeconfig --region us-west-2 --name teable-infra
 
-          # Ordering guard: a deploy attempt that started later wins; an
-          # older attempt must not roll the deployments back (see prod twin).
-          EPOCH=$(date +%s)
-          CUR=$(kubectl -n teable-staging get deploy teable-staging \
-            -o jsonpath='{.metadata.annotations.teable\.io/deploy-epoch}' 2>/dev/null || echo "")
-          if [ -n "$CUR" ] && [ "$CUR" -gt "$EPOCH" ]; then
-            echo "::notice::newer deploy-epoch $CUR already applied (mine: $EPOCH); skipping EKS roll"
-            exit 0
-          fi
+          # Ordering guard: token = run id (assigned at run creation, immune
+          # to stage delays); CAS via resourceVersion (see prod twin).
+          MY_ID=${{ github.run_id }}
+          for attempt in 1 2 3 4 5; do
+            read -r RV CUR <<<"$(kubectl -n teable-staging get deploy teable-staging \
+              -o jsonpath='{.metadata.resourceVersion} {.metadata.annotations.teable\.io/deploy-run-id}')"
+            if [ -n "$CUR" ] && [ "$CUR" -ge "$MY_ID" ] 2>/dev/null; then
+              echo "::notice::run $CUR (>= mine $MY_ID) already deployed EKS; skipping"
+              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            kubectl -n teable-staging annotate --overwrite --resource-version="$RV" \
+              deploy/teable-staging teable.io/deploy-run-id="$MY_ID" 2>/dev/null && break
+            [ "$attempt" = "5" ] && echo "::error::deploy-run-id CAS failed 5x" && exit 1
+            sleep 2
+          done
 
           # Resolve the digests the staging tags point at RIGHT NOW (after
           # patch-cdn potentially rewrote them earlier in this run).
@@ -489,10 +497,13 @@ jobs:
             sandbox="${ECR}/teable/teable-sandbox-cloud@${SANDBOX_DIGEST}"
 
           kubectl -n teable-staging annotate --overwrite \
-            deploy/teable-staging deploy/teable-staging-byodb-worker deploy/teable-sandbox \
-            teable.io/deploy-epoch="$EPOCH" teable.io/deploy-release="$STAGING_TAG"
+            deploy/teable-staging-byodb-worker deploy/teable-sandbox \
+            teable.io/deploy-run-id="$MY_ID" teable.io/deploy-release="$STAGING_TAG"
+          kubectl -n teable-staging annotate --overwrite \
+            deploy/teable-staging teable.io/deploy-release="$STAGING_TAG"
 
       - name: Wait for rollouts
+        if: steps.roll.outputs.skipped != 'true'
         run: |
           set -euo pipefail
           kubectl -n teable-staging rollout status deploy/teable-staging --timeout=300s
@@ -500,6 +511,7 @@ jobs:
           kubectl -n teable-staging rollout status deploy/teable-sandbox --timeout=300s
 
       - name: Smoke check through the ALB
+        if: steps.roll.outputs.skipped != 'true'
         run: |
           set -euo pipefail
           for i in $(seq 1 10); do

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -438,6 +438,8 @@ jobs:
     name: Deploy to Staging EKS
     needs: [prepare, deploy-app, deploy-sandbox]
     runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.roll.outputs.skipped }}
     permissions:
       id-token: write
       contents: read
@@ -465,11 +467,13 @@ jobs:
           for attempt in 1 2 3 4 5; do
             read -r RV CUR <<<"$(kubectl -n teable-staging get deploy teable-staging \
               -o jsonpath='{.metadata.resourceVersion} {.metadata.annotations.teable\.io/deploy-run-id}')"
-            if [ -n "$CUR" ] && [ "$CUR" -ge "$MY_ID" ] 2>/dev/null; then
-              echo "::notice::run $CUR (>= mine $MY_ID) already deployed EKS; skipping"
+            if [ -n "$CUR" ] && [ "$CUR" -gt "$MY_ID" ] 2>/dev/null; then
+              echo "::notice::run $CUR (> mine $MY_ID) already deployed EKS; skipping"
               echo "skipped=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            # rerun of the same run keeps its run_id — resume, don't skip
+            [ "$CUR" = "$MY_ID" ] && echo "resuming own run $MY_ID" && break
             kubectl -n teable-staging annotate --overwrite --resource-version="$RV" \
               deploy/teable-staging teable.io/deploy-run-id="$MY_ID" 2>/dev/null && break
             [ "$attempt" = "5" ] && echo "::error::deploy-run-id CAS failed 5x" && exit 1
@@ -501,6 +505,13 @@ jobs:
             teable.io/deploy-run-id="$MY_ID" teable.io/deploy-release="$STAGING_TAG"
           kubectl -n teable-staging annotate --overwrite \
             deploy/teable-staging teable.io/deploy-release="$STAGING_TAG"
+
+          FINAL=$(kubectl -n teable-staging get deploy teable-staging \
+            -o jsonpath='{.metadata.annotations.teable\.io/deploy-run-id}')
+          if [ "$FINAL" != "$MY_ID" ]; then
+            echo "::error::run $FINAL overlapped this deploy — EKS may hold mixed images; redeploy the latest build"
+            exit 1
+          fi
 
       - name: Wait for rollouts
         if: steps.roll.outputs.skipped != 'true'
@@ -560,8 +571,12 @@ jobs:
           PR: ${{ inputs.release_pr || '无' }}
           ISSUES: ${{ inputs.release_issues || '无关联 Issue' }}
           DEPLOY_SUCCESS: ${{ (needs.deploy-app.result == 'success' && needs.deploy-sandbox.result == 'success' && needs.deploy-eks.result == 'success') && 'true' || 'false' }}
+          EKS_SUPERSEDED: ${{ needs.deploy-eks.outputs.skipped == 'true' && 'true' || 'false' }}
         run: |
           RELEASE_TAG="${IMAGE_TAG}"
+          if [ "$EKS_SUPERSEDED" = "true" ]; then
+            RELEASE_TAG="${RELEASE_TAG}（EKS 侧被更新的 run 取代，未安装本版本）"
+          fi
 
           if [ "$DEPLOY_SUCCESS" = "true" ]; then
             HEADER_COLOR="yellow"

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -81,14 +81,10 @@ on:
       TEABLE_API_TOKEN:
         required: false
 
-# Serialize staging deploys (Codex review on #82): without this, an older
-# run finishing late could roll the shared EKS deployments back to an older
-# digest after a newer run already completed. Queue, never cancel: every
-# triggered build still deploys, strictly in order.
-concurrency:
-  group: staging-deploy
-  cancel-in-progress: false
-
+# NOTE: no workflow-level concurrency — GitHub cancels superseded PENDING
+# runs in a group, which would cancel a whole staging release (incl. its DB
+# migration). Cross-run EKS ordering is guarded inside deploy-eks with a
+# deploy-epoch annotation instead (older attempt refuses to overwrite newer).
 jobs:
   prepare:
     name: Prepare Deployment
@@ -451,6 +447,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::649941507946:role/teable-staging-eks-deploy
+          role-session-name: eks-staging-deploy
           aws-region: us-west-2
 
       - name: Roll EKS deployments to this build
@@ -460,6 +457,16 @@ jobs:
         run: |
           set -euo pipefail
           aws eks update-kubeconfig --region us-west-2 --name teable-infra
+
+          # Ordering guard: a deploy attempt that started later wins; an
+          # older attempt must not roll the deployments back (see prod twin).
+          EPOCH=$(date +%s)
+          CUR=$(kubectl -n teable-staging get deploy teable-staging \
+            -o jsonpath='{.metadata.annotations.teable\.io/deploy-epoch}' 2>/dev/null || echo "")
+          if [ -n "$CUR" ] && [ "$CUR" -gt "$EPOCH" ]; then
+            echo "::notice::newer deploy-epoch $CUR already applied (mine: $EPOCH); skipping EKS roll"
+            exit 0
+          fi
 
           # Resolve the digests the staging tags point at RIGHT NOW (after
           # patch-cdn potentially rewrote them earlier in this run).
@@ -480,6 +487,10 @@ jobs:
             teable="${ECR}/teable/teable-cloud@${APP_DIGEST}"
           kubectl -n teable-staging set image deploy/teable-sandbox \
             sandbox="${ECR}/teable/teable-sandbox-cloud@${SANDBOX_DIGEST}"
+
+          kubectl -n teable-staging annotate --overwrite \
+            deploy/teable-staging deploy/teable-staging-byodb-worker deploy/teable-sandbox \
+            teable.io/deploy-epoch="$EPOCH" teable.io/deploy-release="$STAGING_TAG"
 
       - name: Wait for rollouts
         run: |


### PR DESCRIPTION
对 #84 做事后 Codex 评审（本机 codex，因 #83/#84 合并太快线上 bot 未及运行）发现的问题：

1. **P1** workflow 级 concurrency 会取消被顶掉的 pending run——整条生产发布链（含迁移/promote/aliyun）陪葬，代价大于其防的竞态。两个工作流均改为 deploy-eks 内部的 **deploy-epoch 注解护栏**：后启动者胜，旧尝试主动让位不回滚。
2. **P1** prod deploy-eks 失败会连累 workflow_call 调用方（rollback-launch 的记录步骤会被跳过）。改 **continue-on-error** + 失败时飞书显式告警——被动侧不拦发布，可见性不丢。
3. **P2** TG 健康检查把 draining（socket TG 注销延迟 300s）算进分母造成假红。改为：healthy≥1 且 initial/unhealthy 清零，忽略 draining，窗口放宽到 300s。
4. **P3** 角色名 staging 干 prod 的活：先加 role-session-name 区分 CloudTrail，改名列入清理项。

（Codex 另提的"权重 0 不等于 worker 被动"是双跑模式的已知设计：EKS worker 与 ECS 同 digest 抢队列，07-27 拍板时已含此义。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)