### PR TITLE
ci: 飞书卡片 Author 兜底显示 trigger 来源

### DIFF
--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -567,7 +567,8 @@ jobs:
       - name: Send Feishu staging deploy notification
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
-          AUTHOR: ${{ inputs.release_author || 'unknown' }}
+          # 手动 dispatch 无 release 元数据时,用 trigger 输入标注来源(如运维验证跑),不再显示 unknown
+          AUTHOR: ${{ inputs.release_author || inputs.trigger || 'unknown' }}
           PR: ${{ inputs.release_pr || '无' }}
           ISSUES: ${{ inputs.release_issues || '无关联 Issue' }}
           DEPLOY_SUCCESS: ${{ (needs.deploy-app.result == 'success' && needs.deploy-sandbox.result == 'success' && needs.deploy-eks.result == 'success') && 'true' || 'false' }}


### PR DESCRIPTION
手动 dispatch（运维验证跑）没有 release 元数据，卡片显示 Author: unknown。改为兜底显示 trigger 输入（如 EKS-leg-verification），一眼区分人发的版和验证跑。真实发布行为不变（release_author 优先）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)