### PR TITLE
ci: add skip_deploy flag to preview workflows (build+push only)

### DIFF
--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -112,8 +112,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -110,8 +110,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -112,8 +112,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -112,8 +112,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo


### PR DESCRIPTION
## Summary
- Add a `skip_deploy` flag to the four preview workflows (`manual-preview-cloud`, `manual-preview-ee`, and their `-update` variants).
- When the `repository_dispatch` `client_payload` carries `skip_deploy: true` (boolean or string `"true"`), the `deploy` job is skipped and a new `notify-skip-deploy` job comments on the PR with the pushed image tags (`alpha-pr-<PR>` and the commit SHA).
- Payloads without the field behave exactly as before: build → push → deploy. Fully backward compatible.

## Usage
```json
{
  "event_type": "preview-ee",
  "client_payload": { "pr_number": 123, "ref": "<sha-or-branch>", "skip_deploy": true }
}
```

Note: the dispatch sender lives in teable-ee (PR comment command handler); wiring the flag into a comment command needs a follow-up change there. Direct API dispatches can use it as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)