### PR TITLE
ci: skip_deploy preview runs push images to aliyun + ghcr

### DIFF
--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -104,6 +104,8 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
 
       - name: 📦 Build and push
+        env:
+          PREVIEW_PUSH_REGISTRIES: ${{ (github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true') && 'registry.cn-shenzhen.aliyuncs.com,ghcr.io' || '' }}
         run: |
           zx scripts/build-image.mjs --file=dockers/teable/${{ matrix.file }} \
               --build-arg="ENABLE_CSP=false" \

--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -112,8 +112,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -101,6 +101,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: 📦 Build and push
+        env:
+          PREVIEW_PUSH_REGISTRIES: ${{ (github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true') && 'registry.cn-shenzhen.aliyuncs.com,ghcr.io' || '' }}
         run: |
           zx scripts/build-image.mjs --file=dockers/teable/${{ matrix.file }} \
               --build-arg="ENABLE_CSP=false" \

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -110,8 +110,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -112,8 +112,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -104,6 +104,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: 📦 Build and push
+        env:
+          PREVIEW_PUSH_REGISTRIES: ${{ (github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true') && 'registry.cn-shenzhen.aliyuncs.com,ghcr.io' || '' }}
         run: |
           zx scripts/build-image.mjs --file=dockers/teable/${{ matrix.file }} \
               --build-arg="ENABLE_CSP=false" \

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -112,8 +112,23 @@ jobs:
               --platform="linux/amd64" \
               --push
 
+  notify-skip-deploy:
+    needs: [build-push]
+    if: github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment images pushed on PR
+        run: |
+          BODY="📦 Images built and pushed, deploy skipped. Image tags: alpha-pr-${{ github.event.client_payload.pr_number }}, ${{ needs.build-push.outputs.main_commit_sha }}"
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PACKAGES_KEY }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/teableio/teable-ee/issues/${{ github.event.client_payload.pr_number }}/comments" \
+            -d "{\"body\":\"${BODY}\"}"
+
   deploy:
     needs: [build-push]
+    if: github.event.client_payload.skip_deploy != true && github.event.client_payload.skip_deploy != 'true'
     runs-on: ubuntu-latest
     env:
       NAMESPACE: 38puz7wo

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -103,6 +103,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: 📦 Build and push
+        env:
+          PREVIEW_PUSH_REGISTRIES: ${{ (github.event.client_payload.skip_deploy == true || github.event.client_payload.skip_deploy == 'true') && 'registry.cn-shenzhen.aliyuncs.com,ghcr.io' || '' }}
         run: |
           zx scripts/build-image.mjs --file=dockers/teable/${{ matrix.file }} \
               --build-arg="ENABLE_CSP=false" \


### PR DESCRIPTION
## Summary

Two commits that together make preview build-only runs usable as an image delivery channel:

1. **`skip_deploy` flag** (b4c2ece): `repository_dispatch` payloads for all 4 preview workflows (cloud/ee × create/update) accept `skip_deploy: true` — the run builds and pushes images, then comments the tags on the PR instead of deploying to the Sealos preview cluster.
2. **Push registry selection** (422fc87): since April, teable-ee's `build-image.mjs` filters preview pushes down to the Aliyun registry only (`teableio/teable-ee@53dda605`), which is why `ghcr.io/teableio/teable-cloud-preview` has had no new tags for ~4 months despite ghcr being in every workflow's tag list. This PR sets `PREVIEW_PUSH_REGISTRIES=registry.cn-shenzhen.aliyuncs.com,ghcr.io` on the build step when `skip_deploy` is set, so build-only runs land on Aliyun + GHCR (ECR stays excluded). Regular preview deploys pass an empty value and keep the current Aliyun-only fast path.

## Dependency

`PREVIEW_PUSH_REGISTRIES` is introduced by teableio/teable-ee#2864 (open). Until that merges, the env var is ignored and skip_deploy runs keep pushing to Aliyun only — safe to merge in either order.

## Test plan

- [ ] Dispatch `preview-cloud` with `skip_deploy: true` after teable-ee#2864 merges; verify the PR comment lists tags and `ghcr.io/teableio/teable-cloud-preview:alpha-pr-<n>` exists
- [ ] Dispatch a regular preview and confirm the build still pushes Aliyun only (filter log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)