### PR TITLE
ci: cloud preview sandbox agent + preset-env wiring T6594

### DIFF
--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -32,6 +32,11 @@ jobs:
             file: Dockerfile
           - image: teable-sandbox-cloud-preview
             file: Dockerfile.sandbox
+          # The app pulls its sandbox agent as <prefix>:<own BUILD_VERSION>, and
+          # preview builds stamp BUILD_VERSION with the PR tag — so the agent has
+          # to be built here for that tag to exist. Mirrors the EE preview lane.
+          - image: teable-sandbox-agent-cloud-preview
+            file: Dockerfile.sandbox-agent
     steps:
       - name: Record start time
         id: start_time

--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -191,6 +191,7 @@ jobs:
           # non-sensitive entries and stays editable in the UI, the secret holds
 
           # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_DEFAULTS: SANDBOX_OPENSANDBOX_IMAGE=registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-cloud-preview
           PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
@@ -305,6 +306,7 @@ jobs:
         if: steps.check_deploy.outcome == 'success'
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          PREVIEW_PRESET_ENV_DEFAULTS: SANDBOX_OPENSANDBOX_IMAGE=registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-cloud-preview
           PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |

--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -186,8 +186,12 @@ jobs:
           IMAGE_TAG: ${{ needs.build-push.outputs.main_commit_sha }}
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
-          # Optional dotenv blob of preset env for previews; see
-          # render-preview-env-secret.sh. Unset just means no preset env.
+          # Preset env for previews, both halves optional: the variable holds
+
+          # non-sensitive entries and stays editable in the UI, the secret holds
+
+          # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_CONFIG_SOURCE}" ]; then
@@ -301,6 +305,7 @@ jobs:
         if: steps.check_deploy.outcome == 'success'
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           mkdir -p ~/.kube

--- a/.github/workflows/manual-preview-cloud-update.yml
+++ b/.github/workflows/manual-preview-cloud-update.yml
@@ -186,6 +186,9 @@ jobs:
           IMAGE_TAG: ${{ needs.build-push.outputs.main_commit_sha }}
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
+          # Optional dotenv blob of preset env for previews; see
+          # render-preview-env-secret.sh. Unset just means no preset env.
+          PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_CONFIG_SOURCE}" ]; then
             echo "::error::Missing PREVIEW_CONFIG_SOURCE secret"
@@ -241,7 +244,9 @@ jobs:
                             key: PREVIEW_CONFIG_SOURCE
           EOF
           )
-          PREVIEW_CONFIG_SECRET="${PREVIEW_CONFIG_SECRET}" PREVIEW_CONFIG_ENV="${PREVIEW_CONFIG_ENV}" perl -0pi -e 's/# __PREVIEW_EXTRA_RESOURCES__/$ENV{PREVIEW_CONFIG_SECRET}/g; s/            #__PREVIEW_EXTRA_ENV__/$ENV{PREVIEW_CONFIG_ENV}/g' deploy.yaml
+          PREVIEW_ENV_SECRET=$(INSTANCE_NAME="${{ env.INSTANCE_NAME }}" bash .github/scripts/render-preview-env-secret.sh)
+          PREVIEW_EXTRA_RESOURCES="${PREVIEW_CONFIG_SECRET}"$'\n'"${PREVIEW_ENV_SECRET}"
+          PREVIEW_EXTRA_RESOURCES="${PREVIEW_EXTRA_RESOURCES}" PREVIEW_CONFIG_ENV="${PREVIEW_CONFIG_ENV}" perl -0pi -e 's/# __PREVIEW_EXTRA_RESOURCES__/$ENV{PREVIEW_EXTRA_RESOURCES}/g; s/            #__PREVIEW_EXTRA_ENV__/$ENV{PREVIEW_CONFIG_ENV}/g' deploy.yaml
 
       - name: Apply deploy job (fallback create)
         if: steps.check_deploy.outcome == 'failure'
@@ -272,6 +277,42 @@ jobs:
 
           kubectl -n ns-${{ env.NAMESPACE }} set env deployment/teable-${{ env.INSTANCE_NAME }} \
             --from=secret/teable-${{ env.INSTANCE_NAME }}-preview-config
+
+          rm -f ~/.kube/config
+
+      # The normal update path never re-renders the template, so teable-ee is
+      # not at the workspace root here. Checking it out under its own path
+      # leaves the root untouched.
+      - name: Checkout preview tooling
+        if: steps.check_deploy.outcome == 'success'
+        uses: actions/checkout@v4
+        with:
+          repository: teableio/teable-ee
+          token: ${{ secrets.PACKAGES_KEY }}
+          ref: ${{ github.event.client_payload.ref }}
+          path: preview-tooling
+
+      # Previews created before envFrom existed have no reference to the preset
+      # Secret, and the update path does not re-apply the template — so the
+      # Deployment is patched too, not just the Secret refreshed. Both are
+      # idempotent. New Secret contents reach the container on the image
+      # rollout that follows, since envFrom is read at pod start.
+      - name: Ensure preview preset env
+        if: steps.check_deploy.outcome == 'success'
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
+        run: |
+          mkdir -p ~/.kube
+          echo "${KUBE_CONFIG}" | base64 -d > ~/.kube/config
+
+          INSTANCE_NAME="${{ env.INSTANCE_NAME }}" \
+            bash preview-tooling/.github/scripts/render-preview-env-secret.sh \
+            | kubectl -n ns-${{ env.NAMESPACE }} apply -f -
+
+          kubectl -n ns-${{ env.NAMESPACE }} patch deployment teable-${{ env.INSTANCE_NAME }} \
+            --type=strategic \
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"teable-${{ env.INSTANCE_NAME }}","envFrom":[{"secretRef":{"name":"teable-${{ env.INSTANCE_NAME }}-preview-env","optional":true}}]}]}}}}'
 
           rm -f ~/.kube/config
 

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -32,6 +32,11 @@ jobs:
             file: Dockerfile
           - image: teable-sandbox-cloud-preview
             file: Dockerfile.sandbox
+          # The app pulls its sandbox agent as <prefix>:<own BUILD_VERSION>, and
+          # preview builds stamp BUILD_VERSION with the PR tag — so the agent has
+          # to be built here for that tag to exist. Mirrors the EE preview lane.
+          - image: teable-sandbox-agent-cloud-preview
+            file: Dockerfile.sandbox-agent
     steps:
       - name: Record start time
         id: start_time

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -176,6 +176,9 @@ jobs:
           IMAGE_TAG: ${{ steps.get_sha.outputs.sha }}
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
+          # Optional dotenv blob of preset env for previews; see
+          # render-preview-env-secret.sh. Unset just means no preset env.
+          PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_CONFIG_SOURCE}" ]; then
             echo "::error::Missing PREVIEW_CONFIG_SOURCE secret"
@@ -231,7 +234,9 @@ jobs:
                             key: PREVIEW_CONFIG_SOURCE
           EOF
           )
-          PREVIEW_CONFIG_SECRET="${PREVIEW_CONFIG_SECRET}" PREVIEW_CONFIG_ENV="${PREVIEW_CONFIG_ENV}" perl -0pi -e 's/# __PREVIEW_EXTRA_RESOURCES__/$ENV{PREVIEW_CONFIG_SECRET}/g; s/            #__PREVIEW_EXTRA_ENV__/$ENV{PREVIEW_CONFIG_ENV}/g' deploy.yaml
+          PREVIEW_ENV_SECRET=$(INSTANCE_NAME="${{ env.INSTANCE_NAME }}" bash .github/scripts/render-preview-env-secret.sh)
+          PREVIEW_EXTRA_RESOURCES="${PREVIEW_CONFIG_SECRET}"$'\n'"${PREVIEW_ENV_SECRET}"
+          PREVIEW_EXTRA_RESOURCES="${PREVIEW_EXTRA_RESOURCES}" PREVIEW_CONFIG_ENV="${PREVIEW_CONFIG_ENV}" perl -0pi -e 's/# __PREVIEW_EXTRA_RESOURCES__/$ENV{PREVIEW_EXTRA_RESOURCES}/g; s/            #__PREVIEW_EXTRA_ENV__/$ENV{PREVIEW_CONFIG_ENV}/g' deploy.yaml
 
       - name: Apply deploy job
         uses: actions-hub/kubectl@master

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -176,8 +176,12 @@ jobs:
           IMAGE_TAG: ${{ steps.get_sha.outputs.sha }}
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
-          # Optional dotenv blob of preset env for previews; see
-          # render-preview-env-secret.sh. Unset just means no preset env.
+          # Preset env for previews, both halves optional: the variable holds
+
+          # non-sensitive entries and stays editable in the UI, the secret holds
+
+          # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_CONFIG_SOURCE}" ]; then

--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -181,6 +181,7 @@ jobs:
           # non-sensitive entries and stays editable in the UI, the secret holds
 
           # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_DEFAULTS: SANDBOX_OPENSANDBOX_IMAGE=registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-cloud-preview
           PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -188,6 +188,9 @@ jobs:
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_EE_ENTERPRISE_LICENSE_KEY: ${{ secrets.PREVIEW_EE_ENTERPRISE_LICENSE_KEY }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
+          # Optional dotenv blob of preset env for previews; see
+          # render-preview-env-secret.sh. Unset just means no preset env.
+          PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_EE_ENTERPRISE_LICENSE_KEY}" ]; then
             echo "::error::Missing PREVIEW_EE_ENTERPRISE_LICENSE_KEY secret"
@@ -272,7 +275,8 @@ jobs:
                             key: PREVIEW_CONFIG_SOURCE
           EOF
           )
-          PREVIEW_EXTRA_RESOURCES="${LICENSE_SECRET}"$'\n'"${PREVIEW_CONFIG_SECRET}"
+          PREVIEW_ENV_SECRET=$(INSTANCE_NAME="${{ env.INSTANCE_NAME }}" bash .github/scripts/render-preview-env-secret.sh)
+          PREVIEW_EXTRA_RESOURCES="${LICENSE_SECRET}"$'\n'"${PREVIEW_CONFIG_SECRET}"$'\n'"${PREVIEW_ENV_SECRET}"
           PREVIEW_EXTRA_ENV="${LICENSE_ENV}
           ${PREVIEW_CONFIG_ENV}"
           PREVIEW_EXTRA_RESOURCES="${PREVIEW_EXTRA_RESOURCES}" PREVIEW_EXTRA_ENV="${PREVIEW_EXTRA_ENV}" perl -0pi -e 's/# __PREVIEW_EXTRA_RESOURCES__/$ENV{PREVIEW_EXTRA_RESOURCES}/g; s/            #__PREVIEW_EXTRA_ENV__/$ENV{PREVIEW_EXTRA_ENV}/g' deploy.yaml
@@ -340,6 +344,42 @@ jobs:
 
           kubectl -n ns-${{ env.NAMESPACE }} set env deployment/teable-${{ env.INSTANCE_NAME }} \
             --from=secret/teable-${{ env.INSTANCE_NAME }}-preview-config
+
+          rm -f ~/.kube/config
+
+      # The normal update path never re-renders the template, so teable-ee is
+      # not at the workspace root here. Checking it out under its own path
+      # leaves the root and deployment-tooling untouched.
+      - name: Checkout preview tooling
+        if: steps.check_deploy.outcome == 'success'
+        uses: actions/checkout@v4
+        with:
+          repository: teableio/teable-ee
+          token: ${{ secrets.PACKAGES_KEY }}
+          ref: ${{ github.event.client_payload.ref }}
+          path: preview-tooling
+
+      # Previews created before envFrom existed have no reference to the preset
+      # Secret, and the update path does not re-apply the template — so the
+      # Deployment is patched too, not just the Secret refreshed. Both are
+      # idempotent. New Secret contents reach the container on the image
+      # rollout that follows, since envFrom is read at pod start.
+      - name: Ensure preview preset env
+        if: steps.check_deploy.outcome == 'success'
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
+        run: |
+          mkdir -p ~/.kube
+          echo "${KUBE_CONFIG}" | base64 -d > ~/.kube/config
+
+          INSTANCE_NAME="${{ env.INSTANCE_NAME }}" \
+            bash preview-tooling/.github/scripts/render-preview-env-secret.sh \
+            | kubectl -n ns-${{ env.NAMESPACE }} apply -f -
+
+          kubectl -n ns-${{ env.NAMESPACE }} patch deployment teable-${{ env.INSTANCE_NAME }} \
+            --type=strategic \
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"teable-${{ env.INSTANCE_NAME }}","envFrom":[{"secretRef":{"name":"teable-${{ env.INSTANCE_NAME }}-preview-env","optional":true}}]}]}}}}'
 
           rm -f ~/.kube/config
 

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -193,6 +193,7 @@ jobs:
           # non-sensitive entries and stays editable in the UI, the secret holds
 
           # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_DEFAULTS: SANDBOX_OPENSANDBOX_IMAGE=registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-ee-preview
           PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
@@ -372,6 +373,7 @@ jobs:
         if: steps.check_deploy.outcome == 'success'
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          PREVIEW_PRESET_ENV_DEFAULTS: SANDBOX_OPENSANDBOX_IMAGE=registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-ee-preview
           PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |

--- a/.github/workflows/manual-preview-ee-update.yml
+++ b/.github/workflows/manual-preview-ee-update.yml
@@ -188,8 +188,12 @@ jobs:
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_EE_ENTERPRISE_LICENSE_KEY: ${{ secrets.PREVIEW_EE_ENTERPRISE_LICENSE_KEY }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
-          # Optional dotenv blob of preset env for previews; see
-          # render-preview-env-secret.sh. Unset just means no preset env.
+          # Preset env for previews, both halves optional: the variable holds
+
+          # non-sensitive entries and stays editable in the UI, the secret holds
+
+          # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_EE_ENTERPRISE_LICENSE_KEY}" ]; then
@@ -368,6 +372,7 @@ jobs:
         if: steps.check_deploy.outcome == 'success'
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+          PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           mkdir -p ~/.kube

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -179,6 +179,7 @@ jobs:
           # non-sensitive entries and stays editable in the UI, the secret holds
 
           # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_DEFAULTS: SANDBOX_OPENSANDBOX_IMAGE=registry.cn-shenzhen.aliyuncs.com/teable/teable-sandbox-agent-ee-preview
           PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -174,6 +174,9 @@ jobs:
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_EE_ENTERPRISE_LICENSE_KEY: ${{ secrets.PREVIEW_EE_ENTERPRISE_LICENSE_KEY }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
+          # Optional dotenv blob of preset env for previews; see
+          # render-preview-env-secret.sh. Unset just means no preset env.
+          PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_EE_ENTERPRISE_LICENSE_KEY}" ]; then
             echo "::error::Missing PREVIEW_EE_ENTERPRISE_LICENSE_KEY secret"
@@ -258,7 +261,8 @@ jobs:
                             key: PREVIEW_CONFIG_SOURCE
           EOF
           )
-          PREVIEW_EXTRA_RESOURCES="${LICENSE_SECRET}"$'\n'"${PREVIEW_CONFIG_SECRET}"
+          PREVIEW_ENV_SECRET=$(INSTANCE_NAME="${{ env.INSTANCE_NAME }}" bash .github/scripts/render-preview-env-secret.sh)
+          PREVIEW_EXTRA_RESOURCES="${LICENSE_SECRET}"$'\n'"${PREVIEW_CONFIG_SECRET}"$'\n'"${PREVIEW_ENV_SECRET}"
           PREVIEW_EXTRA_ENV="${LICENSE_ENV}
           ${PREVIEW_CONFIG_ENV}"
           PREVIEW_EXTRA_RESOURCES="${PREVIEW_EXTRA_RESOURCES}" PREVIEW_EXTRA_ENV="${PREVIEW_EXTRA_ENV}" perl -0pi -e 's/# __PREVIEW_EXTRA_RESOURCES__/$ENV{PREVIEW_EXTRA_RESOURCES}/g; s/            #__PREVIEW_EXTRA_ENV__/$ENV{PREVIEW_EXTRA_ENV}/g' deploy.yaml

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -174,8 +174,12 @@ jobs:
           ENABLE_TRACING: ${{ steps.labels.outputs.enable_tracing }}
           PREVIEW_EE_ENTERPRISE_LICENSE_KEY: ${{ secrets.PREVIEW_EE_ENTERPRISE_LICENSE_KEY }}
           PREVIEW_CONFIG_SOURCE: ${{ secrets.PREVIEW_CONFIG_SOURCE }}
-          # Optional dotenv blob of preset env for previews; see
-          # render-preview-env-secret.sh. Unset just means no preset env.
+          # Preset env for previews, both halves optional: the variable holds
+
+          # non-sensitive entries and stays editable in the UI, the secret holds
+
+          # credentials and wins on duplicate keys. See render-preview-env-secret.sh.
+          PREVIEW_PRESET_ENV_VARS: ${{ vars.PREVIEW_PRESET_ENV_VARS }}
           PREVIEW_PRESET_ENV: ${{ secrets.PREVIEW_PRESET_ENV }}
         run: |
           if [ -z "${PREVIEW_EE_ENTERPRISE_LICENSE_KEY}" ]; then


### PR DESCRIPTION
Companion to teableio/teable-ee#2886. Two changes to the preview lanes.

## 1. Cloud preview builds the sandbox agent image

The app spawns its sandbox agent from `${SANDBOX_OPENSANDBOX_IMAGE}:${BUILD_VERSION}`, and the EE preview lane has had the `Dockerfile.sandbox-agent` leg all along — the cloud lane built only the app and the code-exec sandbox, so a cloud PR preview never published an agent image under any tag.

`Dockerfile.sandbox-agent` defaults `SANDBOX_AGENT_BASE_IMAGE` to `teable-sandbox-agent-base:latest` specifically so preview and local builds work without computing the inputs-hash first, so the leg needs no extra build args and no dependency on `ensure-agent-base`. Both cloud preview paths are label-gated, so the extra build time is opt-in.

## 2. Preset-env wiring

teable-ee now renders a per-instance Secret from a single `PREVIEW_PRESET_ENV` dotenv blob, which the preview template consumes via `envFrom`. This wires that renderer into every path that can produce a preview: both create lanes, both fallback-create lanes, and both normal update lanes.

The update lanes never re-render the template, so previews created before `envFrom` existed carry no reference to the Secret. Those get an idempotent strategic-merge patch instead, plus their own teable-ee checkout under `preview-tooling/` — a root checkout there would wipe `deployment-tooling/`, which the BYODB worker step depends on.

New Secret contents reach the container on the image rollout that follows, since `envFrom` is read at pod start; preview updates always carry a new sha tag, so that rollout always happens.

The secret is optional throughout: unset simply means no preset env, which is what every existing preview gets until it is populated.

## Verification

All four workflows parse; the create-path render was simulated end to end against the updated template (valid manifest, Secret keys decode, `envFrom` present, existing env untouched), and the empty-secret case renders `data: {}` and still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)