### PR TITLE
为 CN 部署增加超时告警和镜像重试

### DIFF
--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -108,6 +108,8 @@ on:
         required: true
       TEABLE_API_TOKEN:
         required: false
+      LARK_BOT_URL:
+        required: false
       # Used by the ensure-aliyun job (ghcr pull / Aliyun push) — callers
       # not using `secrets: inherit` must pass these for the self-heal
       # copy to work.
@@ -136,11 +138,26 @@ jobs:
   ensure-aliyun:
     name: Ensure release images on Aliyun
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Install skopeo
         run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if sudo timeout 180s apt-get update \
+                -o Acquire::Retries=3 \
+                -o Acquire::http::Timeout=30 \
+                -o Acquire::https::Timeout=30 && \
+               sudo env DEBIAN_FRONTEND=noninteractive \
+                timeout 180s apt-get install -y skopeo; then
+              exit 0
+            fi
+            echo "::warning::skopeo install attempt ${attempt} failed"
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          echo "::error::skopeo installation failed after 3 attempts"
+          exit 1
 
       - name: Stamp and copy any missing images
         env:
@@ -482,3 +499,61 @@ jobs:
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
           TARGET: cn
         run: bash .github/scripts/finalize-teable-release.sh
+
+  notify-failure:
+    name: Report teable.cn deploy failure
+    needs: [ensure-aliyun, patch-cdn, deploy, notify, finalize-release]
+    if: >-
+      always() &&
+      inputs.record_launch != false &&
+      (needs.ensure-aliyun.result == 'failure' ||
+       needs.ensure-aliyun.result == 'cancelled' ||
+       needs.patch-cdn.result == 'failure' ||
+       needs.patch-cdn.result == 'cancelled' ||
+       needs.deploy.result == 'failure' ||
+       needs.deploy.result == 'cancelled' ||
+       needs.notify.result == 'failure' ||
+       needs.notify.result == 'cancelled' ||
+       needs.finalize-release.result == 'failure' ||
+       needs.finalize-release.result == 'cancelled')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Feishu failure notification
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
+          ENSURE_RESULT: ${{ needs.ensure-aliyun.result }}
+          PATCH_RESULT: ${{ needs.patch-cdn.result }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          LAUNCH_RESULT: ${{ needs.notify.result }}
+          FINALIZE_RESULT: ${{ needs.finalize-release.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "::error::LARK_BOT_URL is not configured"
+            exit 1
+          fi
+
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          card_payload=$(jq -n \
+            --arg title "teable.cn 发布失败 ${{ inputs.image_tag }}" \
+            --arg ensure "$ENSURE_RESULT" \
+            --arg patch "$PATCH_RESULT" \
+            --arg deploy "$DEPLOY_RESULT" \
+            --arg launch "$LAUNCH_RESULT" \
+            --arg finalize "$FINALIZE_RESULT" \
+            --arg url "$run_url" \
+            '{
+              "msg_type": "interactive",
+              "card": {
+                "header": {
+                  "title": {"tag": "plain_text", "content": $title},
+                  "template": "red"
+                },
+                "elements": [
+                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**Aliyun 镜像准备**: " + $ensure + "\n**CDN patch**: " + $patch + "\n**Sealos 部署**: " + $deploy + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n发布锁会保留至过期，请先核对 teable.cn 线上状态。\n[查看 Actions](" + $url + ")")}}
+                ]
+              }
+            }')
+          curl -fsS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$card_payload" >/dev/null

--- a/.github/workflows/promote-latest-ee.yaml
+++ b/.github/workflows/promote-latest-ee.yaml
@@ -41,6 +41,7 @@ env:
 jobs:
   promote-latest:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
@@ -54,8 +55,22 @@ jobs:
 
       - name: Install skopeo
         run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if sudo timeout 180s apt-get update \
+                -o Acquire::Retries=3 \
+                -o Acquire::http::Timeout=30 \
+                -o Acquire::https::Timeout=30 && \
+               sudo env DEBIAN_FRONTEND=noninteractive \
+                timeout 180s apt-get install -y skopeo; then
+              exit 0
+            fi
+            echo "::warning::skopeo install attempt ${attempt} failed"
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          echo "::error::skopeo installation failed after 3 attempts"
+          exit 1
 
       - name: Stamp release on ghcr and copy to Docker Hub
         env:
@@ -64,6 +79,19 @@ jobs:
         run: |
           set -euo pipefail
           BETA_TAG="beta-${RELEASE_ID#release.}"
+
+          retry_registry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+              echo "::warning::registry operation attempt ${attempt} failed; retrying in 15s"
+              sleep 15
+            done
+            echo "::error::registry operation failed after 3 attempts"
+            return 1
+          }
 
           # target -> "staging-source release-image alias-image"
           SPECS=(
@@ -78,7 +106,7 @@ jobs:
             # promote already did (the beta twin may be reaped by then).
             if ! docker buildx imagetools inspect \
                 "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" >/dev/null 2>&1; then
-              docker buildx imagetools create \
+              retry_registry docker buildx imagetools create \
                 --tag "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" \
                 "${REGISTRY_GITHUB}/${STAGING}:${BETA_TAG}"
             fi
@@ -95,13 +123,13 @@ jobs:
             # the GitHub Release (and never does for a bare promote-ee),
             # which matches how the old post-hoc stamp behaved.
             if [ "$RELEASE" = "teable" ]; then
-              docker buildx imagetools create \
+              retry_registry docker buildx imagetools create \
                 --annotation "index:org.opencontainers.image.description=Release note: https://github.com/${OSS_REPO}/releases/tag/${RELEASE_ID}" \
                 --tag "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}" \
                 "${REGISTRY_GITHUB}/${RELEASE}:${RELEASE_ID}"
             fi
 
-            docker buildx imagetools create \
+            retry_registry docker buildx imagetools create \
               --tag "${REGISTRY_GITHUB}/${RELEASE}:latest" \
               --tag "${REGISTRY_GITHUB}/${ALIAS}:${RELEASE_ID}" \
               --tag "${REGISTRY_GITHUB}/${ALIAS}:latest" \
@@ -109,7 +137,7 @@ jobs:
 
             for image in "$RELEASE" "$ALIAS"; do
               for tag in "${RELEASE_ID}" latest; do
-                skopeo copy --all \
+                retry_registry skopeo copy --all \
                   --src-creds="$SRC_CREDS" \
                   --dest-creds="$DST_CREDS" \
                   "docker://${REGISTRY_GITHUB}/${image}:${RELEASE_ID}" \
@@ -123,7 +151,7 @@ jobs:
           # puts the promoted id's agent there: self-hosted apps pull
           # <prefix>:<their BUILD_VERSION> at sandbox spawn. Aliyun gets
           # the agent release tag via sync-aliyun below.
-          skopeo copy --all \
+          retry_registry skopeo copy --all \
             --src-creds="$SRC_CREDS" \
             --dest-creds="$DST_CREDS" \
             "docker://${REGISTRY_GITHUB}/teable-sandbox-agent:${RELEASE_ID}" \


### PR DESCRIPTION
修复本次 2673 发布暴露的两个问题：

- `Manual Sealos Deploy` 的 skopeo 安装增加超时、重试和 20 分钟 job 上限
- CN 部署失败/取消发送包含各阶段状态与 Actions 链接的飞书卡片
- EE 镜像盖章及 registry copy 增加 3 次重试，避免单次 HTTP/2 抖动中断 Release Note
- EE promotion job 增加 45 分钟上限

验证：actionlint 通过。