### PR TITLE
chore(preview): bootstrap default preview admin and post credentials on the PR T6828

### DIFF
--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -279,6 +279,27 @@ jobs:
         with:
           args: exec deployment/teable-${{ env.INSTANCE_NAME }} -- curl -f --retry 30 --retry-delay 5 --retry-connrefused http://localhost:3000/health
 
+      # Fixed preview admin (dev+pr@teable.io) + full-scope instance API
+      # token, surfaced on the PR by the status comment below. Logic lives in
+      # teable-ee: .github/scripts/preview-bootstrap-admin.sh. Kubeconfig
+      # decoding mirrors actions-hub/kubectl (base64 secret). Never fails the
+      # deploy: continue-on-error, plus a file-exists guard so PR refs that
+      # predate the script still deploy cleanly.
+      - name: Bootstrap preview admin
+        id: preview_admin
+        continue-on-error: true
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          if [ ! -f .github/scripts/preview-bootstrap-admin.sh ]; then
+            echo "preview-bootstrap-admin.sh not on this ref, skipping"
+            exit 0
+          fi
+          printf '%s' "${KUBE_CONFIG}" | base64 -d > "${RUNNER_TEMP}/kubeconfig"
+          chmod 600 "${RUNNER_TEMP}/kubeconfig"
+          export KUBECONFIG="${RUNNER_TEMP}/kubeconfig"
+          INSTANCE_NAME="${{ env.INSTANCE_NAME }}" bash .github/scripts/preview-bootstrap-admin.sh
+
       - name: Create deployment status comment
         if: always()
         run: |
@@ -293,6 +314,12 @@ jobs:
             BODY="**Deployment Status: ${STATUS}** 🔗 Preview URL: ${URL}"
             if [ "$TRACING_ENABLED" = "true" ]; then
               BODY="${BODY} 🔎 Jaeger URL: ${JAEGER_URL}"
+            fi
+            ADMIN_STATUS="${{ steps.preview_admin.outputs.status }}"
+            if [ "$ADMIN_STATUS" = "created" ]; then
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Instance API token: \`${{ steps.preview_admin.outputs.admin_token }}\`"
+            elif [ "$ADMIN_STATUS" = "exists" ]; then
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\` (API token unchanged - see the first deployment comment)"
             fi
           else
             STATUS="❌ Failed"

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -308,6 +308,27 @@ jobs:
         with:
           args: exec deployment/teable-${{ env.INSTANCE_NAME }} -- curl -f --retry 30 --retry-delay 5 --retry-connrefused http://localhost:3000/health
 
+      # Fixed preview admin (dev+pr@teable.io) + full-scope instance API
+      # token, surfaced on the PR by the status comment below. Logic lives in
+      # teable-ee: .github/scripts/preview-bootstrap-admin.sh. Kubeconfig
+      # decoding mirrors actions-hub/kubectl (base64 secret). Never fails the
+      # deploy: continue-on-error, plus a file-exists guard so PR refs that
+      # predate the script still deploy cleanly.
+      - name: Bootstrap preview admin
+        id: preview_admin
+        continue-on-error: true
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        run: |
+          if [ ! -f .github/scripts/preview-bootstrap-admin.sh ]; then
+            echo "preview-bootstrap-admin.sh not on this ref, skipping"
+            exit 0
+          fi
+          printf '%s' "${KUBE_CONFIG}" | base64 -d > "${RUNNER_TEMP}/kubeconfig"
+          chmod 600 "${RUNNER_TEMP}/kubeconfig"
+          export KUBECONFIG="${RUNNER_TEMP}/kubeconfig"
+          INSTANCE_NAME="${{ env.INSTANCE_NAME }}" bash .github/scripts/preview-bootstrap-admin.sh
+
       - name: Create deployment status comment
         if: always()
         run: |
@@ -322,6 +343,12 @@ jobs:
             BODY="**Deployment Status: ${STATUS}** 🔗 Preview URL: ${URL}"
             if [ "$TRACING_ENABLED" = "true" ]; then
               BODY="${BODY} 🔎 Jaeger URL: ${JAEGER_URL}"
+            fi
+            ADMIN_STATUS="${{ steps.preview_admin.outputs.status }}"
+            if [ "$ADMIN_STATUS" = "created" ]; then
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Instance API token: \`${{ steps.preview_admin.outputs.admin_token }}\`"
+            elif [ "$ADMIN_STATUS" = "exists" ]; then
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\` (API token unchanged - see the first deployment comment)"
             fi
           else
             STATUS="❌ Failed"


### PR DESCRIPTION
Companion to teableio/teable-ee#3054 — deploy jobs of `manual-preview-ee.yml` and `manual-preview-cloud.yml` gain a **Bootstrap preview admin** step after the health check:

- decodes `KUBE_CONFIG` (same base64 convention as actions-hub/kubectl) and runs teable-ee's `.github/scripts/preview-bootstrap-admin.sh` from the already-checked-out PR ref;
- the script provisions a fixed admin account (`dev+pr@teable.io` / `teable2026`) and a full-scope `hasFullAccess` instance API token inside the preview (signup API → psql `is_admin` promotion → access-token API, all via `kubectl exec` into the app container);
- the deployment status comment then appends the credentials (`status=created`) or a pointer back to the first deployment comment (`status=exists`, e.g. on job reruns — a token string is only revealed at creation time).

Safety rails: `continue-on-error` plus a file-exists guard, so PR refs that predate the teable-ee script — or any bootstrap hiccup — never fail the deploy. Initial-deploy workflows only: the preview database persists across `*-update` deploys, so the account and token stay valid for the PR's lifetime; a label re-add (fresh instance) bootstraps and comments again.

Merge order: land teableio/teable-ee#3054 first (or merge in any order — the guard makes this PR a no-op until the script exists on the PR ref being previewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)