### PR TITLE
chore(preview): put the preview admin token on its own comment line T6828

### DIFF
--- a/.github/workflows/manual-preview-cloud.yml
+++ b/.github/workflows/manual-preview-cloud.yml
@@ -317,9 +317,9 @@ jobs:
             fi
             ADMIN_STATUS="${{ steps.preview_admin.outputs.status }}"
             if [ "$ADMIN_STATUS" = "created" ]; then
-              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Instance API token: \`${{ steps.preview_admin.outputs.admin_token }}\`"
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Full access token: \`${{ steps.preview_admin.outputs.admin_token }}\`"
             elif [ "$ADMIN_STATUS" = "exists" ]; then
-              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\` (API token unchanged - see the first deployment comment)"
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Full access token: unchanged - see the first deployment comment"
             fi
           else
             STATUS="❌ Failed"

--- a/.github/workflows/manual-preview-ee.yml
+++ b/.github/workflows/manual-preview-ee.yml
@@ -346,9 +346,9 @@ jobs:
             fi
             ADMIN_STATUS="${{ steps.preview_admin.outputs.status }}"
             if [ "$ADMIN_STATUS" = "created" ]; then
-              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Instance API token: \`${{ steps.preview_admin.outputs.admin_token }}\`"
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Full access token: \`${{ steps.preview_admin.outputs.admin_token }}\`"
             elif [ "$ADMIN_STATUS" = "exists" ]; then
-              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\` (API token unchanged - see the first deployment comment)"
+              BODY="${BODY}\n🔐 Admin: \`${{ steps.preview_admin.outputs.admin_email }}\` / \`${{ steps.preview_admin.outputs.admin_password }}\`\n🔑 Full access token: unchanged - see the first deployment comment"
             fi
           else
             STATUS="❌ Failed"


### PR DESCRIPTION
Follow-up to #96, comment layout only. The deployment status comment now renders as three lines:

> **Deployment Status: ✅ Success** 🔗 Preview URL: https://pr-ee-3057.sealoshzh.site
> 🔐 Admin: `dev+pr@teable.io` / `teable2026`
> 🔑 Full access token: `teable_acc…`

and the rerun (`exists`) case keeps the same layout with `🔑 Full access token: unchanged - see the first deployment comment`. Both variants verified locally by rendering the exact BODY through jq, including a token with base64 special characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)