### PR TITLE
跳过已解绑 ALB 目标组的发布门禁

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -117,6 +117,8 @@ on:
         required: false
       INFRA_TEABLE_CN_PREHEAT_TOKEN:
         required: false
+      LARK_BOT_URL:
+        required: false
 
 # NOTE on ordering: no workflow-level concurrency here on purpose — GitHub
 # keeps only ONE pending run per group and CANCELS earlier pending ones,
@@ -497,8 +499,14 @@ jobs:
           # them up to 300s) — they must not fail the check. Settled means:
           # at least one healthy, nothing still initializing or unhealthy.
           for tg_name in teable-eks-app teable-eks-socket; do
-            TG_ARN=$(aws elbv2 describe-target-groups --region us-west-2 \
-              --names "$tg_name" --query 'TargetGroups[0].TargetGroupArn' --output text)
+            TG_JSON=$(aws elbv2 describe-target-groups --region us-west-2 \
+              --names "$tg_name" --output json)
+            TG_ARN=$(jq -r '.TargetGroups[0].TargetGroupArn' <<<"$TG_JSON")
+            LB_COUNT=$(jq '.TargetGroups[0].LoadBalancerArns | length' <<<"$TG_JSON")
+            if [ "$LB_COUNT" = "0" ]; then
+              echo "::notice::$tg_name is detached from all load balancers; skipping stale target health gate"
+              continue
+            fi
             for i in $(seq 1 30); do
               STATES=$(aws elbv2 describe-target-health --region us-west-2 \
                 --target-group-arn "$TG_ARN" \
@@ -539,13 +547,18 @@ jobs:
         if: failure()
         env:
           RELEASE_ID: ${{ inputs.image_tag }}
+          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
         run: |
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "::error::LARK_BOT_URL is not configured"
+            exit 1
+          fi
           PAYLOAD=$(jq -n \
             --arg l1 "🚨 生产 EKS 发布失败: ${RELEASE_ID}" \
             --arg l2 "run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             '{msg_type:"text",content:{text:($l1 + "\n" + $l2)}}')
           HTTP=$(curl -s -o /tmp/feishu.out -w "%{http_code}" -X POST \
-            'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
+            "$FEISHU_WEBHOOK_URL" \
             -H 'Content-Type: application/json' -d "$PAYLOAD")
           if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
             echo "::warning::Feishu alert failed HTTP $HTTP: $(cat /tmp/feishu.out)"

--- a/.github/workflows/manual-ecs-staging-deploy.yml
+++ b/.github/workflows/manual-ecs-staging-deploy.yml
@@ -80,6 +80,8 @@ on:
         required: true
       TEABLE_API_TOKEN:
         required: false
+      LARK_BOT_URL:
+        required: false
 
 # NOTE: no workflow-level concurrency — GitHub cancels superseded PENDING
 # runs in a group, which would cancel a whole staging release (incl. its DB
@@ -473,7 +475,13 @@ jobs:
           ISSUES: ${{ inputs.release_issues || '无关联 Issue' }}
           DEPLOY_SUCCESS: ${{ (needs.deploy-eks.result == 'success' && needs.deploy-eks.outputs.skipped != 'true') && 'true' || 'false' }}
           EKS_SUPERSEDED: ${{ needs.deploy-eks.outputs.skipped == 'true' && 'true' || 'false' }}
+          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
         run: |
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "::error::LARK_BOT_URL is not configured"
+            exit 1
+          fi
+
           RELEASE_TAG="${IMAGE_TAG}"
           if [ "$EKS_SUPERSEDED" = "true" ]; then
             RELEASE_TAG="${RELEASE_TAG}（EKS 侧被更新的 run 取代，未安装本版本）"
@@ -526,7 +534,7 @@ jobs:
             }')
 
           http_code=$(curl -s -w "%{http_code}" -o /tmp/feishu.json -X POST \
-            'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
+            "$FEISHU_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$card_payload")
 

--- a/.github/workflows/publish-release-note.yaml
+++ b/.github/workflows/publish-release-note.yaml
@@ -240,7 +240,12 @@ jobs:
       - name: Send Feishu failure notification
         env:
           STAGE: ${{ needs.promote-ee.result == 'failure' && 'promote-ee(EE 镜像盖章/分发)' || 'publish(渠道发布)' }}
+          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
         run: |
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "::error::LARK_BOT_URL is not configured"
+            exit 1
+          fi
           card_payload=$(jq -n \
             --arg title "❌ Release note 发布失败 ${RELEASE_ID}" \
             --arg stage "$STAGE" \
@@ -258,7 +263,7 @@ jobs:
               }
             }')
           curl -fsS -X POST \
-            'https://open.feishu.cn/open-apis/bot/v2/hook/66b6ebf2-9bbd-4e41-b629-4062a6be4a42' \
+            "$FEISHU_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$card_payload" >/dev/null
           echo "Feishu failure notification sent"


### PR DESCRIPTION
修复 2682 的 AI 发布假失败：

- 健康门禁先读取目标组的 `LoadBalancerArns`
- 已从所有 Load Balancer 解绑的历史目标组记录 notice 并跳过
- 仍挂载的目标组继续执行严格的 healthy/draining 检查
- 将生产、staging 和 Release Note 中硬编码的飞书 Webhook 统一改为 `LARK_BOT_URL` secret

背景：`teable-eks-socket` 已在 2026-08-18 切流到 `teable-prod-via-nginx`，原 target group 的 `LoadBalancerArns=[]`，继续要求它 healthy 会让任何后续 AI 发布假失败。

验证：actionlint、diff check 和 detached/attached fixture 通过。