### PR TITLE
发布失败后自动收敛 Release 锁

### DIFF
--- a/.github/scripts/mark-teable-release-failed.sh
+++ b/.github/scripts/mark-teable-release-failed.sh
@@ -26,8 +26,8 @@ fi
 
 release_metadata=$(jq -cer '.fields.Publishing_Metadata | fromjson' /tmp/release-lock.json) || {
   current_status=$(jq -r '.fields.status // empty' /tmp/release-lock.json)
-  if [ "$current_status" = "Launched" ]; then
-    echo "Release is already fully launched"
+  if [ "$current_status" = "Released" ] || [ "$current_status" = "Launched" ]; then
+    echo "Release is already settled as ${current_status}"
     exit 0
   fi
   echo "Release publishing metadata is missing or invalid"
@@ -37,41 +37,60 @@ release_metadata=$(jq -cer '.fields.Publishing_Metadata | fromjson' /tmp/release
 current_lock_id=$(jq -r '.lockId // empty' <<<"$release_metadata")
 current_state=$(jq -r '.state // empty' <<<"$release_metadata")
 if [ "$current_state" != "launching" ] || [ "$current_lock_id" != "$PUBLISH_LOCK_ID" ]; then
-  echo "Publishing lock changed before ${TARGET} completion was recorded"
-  exit 1
+  echo "Publishing lock changed before ${TARGET} failure was recorded; leaving the newer lock untouched"
+  exit 0
+fi
+
+target_is_locked=$(jq -r --arg target "$TARGET" \
+  '(.targets // []) | index($target) != null' <<<"$release_metadata")
+if [ "$target_is_locked" != "true" ]; then
+  echo "Publishing lock does not include ${TARGET}; leaving it untouched"
+  exit 0
 fi
 
 current_time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-completed_metadata=$(jq -c --arg target "$TARGET" \
-  '.completedTargets = (((.completedTargets // []) + [$target]) | unique)
-   | .failedTargets = ((.failedTargets // []) | map(select(. != $target)))
-   | if .lastFailure.target == $target then del(.lastFailure) else . end' \
-  <<<"$release_metadata")
+failure_message="${FAILURE_MESSAGE:-Release workflow failed}"
+run_url="${RUN_URL:-}"
+failed_metadata=$(jq -c \
+  --arg target "$TARGET" \
+  --arg message "$failure_message" \
+  --arg runUrl "$run_url" \
+  --arg failedAt "$current_time" \
+  '.failedTargets = (((.failedTargets // []) + [$target]) | unique)
+   | .completedTargets = ((.completedTargets // []) | map(select(. != $target)))
+   | .lastFailure = {
+       target: $target,
+       message: $message,
+       runUrl: $runUrl,
+       failedAt: $failedAt
+     }' <<<"$release_metadata")
+
 launched_targets=$(jq -c \
   '((.launchedTargets // []) + (.completedTargets // [])) | unique' \
-  <<<"$completed_metadata")
+  <<<"$failed_metadata")
 terminal_targets=$(jq -c \
   '((.launchedTargets // []) + (.completedTargets // []) + (.failedTargets // [])) | unique' \
-  <<<"$completed_metadata")
-all_launched=$(jq -r 'index("ai") != null and index("cn") != null' <<<"$launched_targets")
+  <<<"$failed_metadata")
 has_pending_lock_target=$(jq -r --argjson terminal "$terminal_targets" \
   'any((.targets // [])[]; . as $target | ($terminal | index($target)) == null)' \
-  <<<"$completed_metadata")
+  <<<"$failed_metadata")
 
-if [ "$all_launched" = "true" ]; then
-  release_status="Launched"
-  publishing_metadata="null"
-elif [ "$has_pending_lock_target" = "true" ]; then
+if [ "$has_pending_lock_target" = "true" ]; then
   release_status="Launching"
-  publishing_metadata=$(jq -Rn --arg value "$completed_metadata" '$value')
+  publishing_metadata=$(jq -Rn --arg value "$failed_metadata" '$value')
 else
   release_status="Released"
   idle_metadata=$(jq -cn \
     --argjson launchedTargets "$launched_targets" \
-    --argjson lastFailure "$(jq -c '.lastFailure // null' <<<"$completed_metadata")" \
+    --argjson lastFailure "$(jq -c '.lastFailure' <<<"$failed_metadata")" \
     --arg updatedAt "$current_time" \
-    '{version: 1, state: "idle", launchedTargets: $launchedTargets, updatedAt: $updatedAt}
-     + if $lastFailure == null then {} else {lastFailure: $lastFailure} end')
+    '{
+      version: 1,
+      state: "idle",
+      launchedTargets: $launchedTargets,
+      lastFailure: $lastFailure,
+      updatedAt: $updatedAt
+    }')
   publishing_metadata=$(jq -Rn --arg value "$idle_metadata" '$value')
 fi
 
@@ -96,9 +115,13 @@ update_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-update.json -X PAT
   -d "$update_payload")
 
 if [ "$update_http_code" -lt 200 ] || [ "$update_http_code" -ge 300 ]; then
-  echo "Failed to update Release progress: HTTP ${update_http_code}"
+  echo "Failed to record ${TARGET} publishing failure: HTTP ${update_http_code}"
   cat /tmp/release-update.json
   exit 1
 fi
 
-echo "Updated Release ${RELEASE_RECORD_ID} to ${release_status}; launched targets: ${launched_targets}"
+if [ "$has_pending_lock_target" = "true" ]; then
+  echo "Recorded ${TARGET} failure; waiting for the remaining lock targets"
+else
+  echo "Recorded ${TARGET} failure and released the publishing lock; launched targets: ${launched_targets}"
+fi

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -543,27 +543,6 @@ jobs:
             echo "skipped=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Alert Feishu on deploy failure
-        if: failure()
-        env:
-          RELEASE_ID: ${{ inputs.image_tag }}
-          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
-        run: |
-          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
-            echo "::error::LARK_BOT_URL is not configured"
-            exit 1
-          fi
-          PAYLOAD=$(jq -n \
-            --arg l1 "🚨 生产 EKS 发布失败: ${RELEASE_ID}" \
-            --arg l2 "run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            '{msg_type:"text",content:{text:($l1 + "\n" + $l2)}}')
-          HTTP=$(curl -s -o /tmp/feishu.out -w "%{http_code}" -X POST \
-            "$FEISHU_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' -d "$PAYLOAD")
-          if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
-            echo "::warning::Feishu alert failed HTTP $HTTP: $(cat /tmp/feishu.out)"
-          fi
-
   promote-latest:
     name: Promote Release Tag to Latest
     needs: [prepare, deploy-eks]
@@ -714,3 +693,95 @@ jobs:
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
           TARGET: ai
         run: bash .github/scripts/finalize-teable-release.sh
+
+  notify-failure:
+    name: Settle and report teable.ai failure
+    needs: [stamp-release, patch-cdn, deploy-eks, promote-latest, sync-aliyun, notify, finalize-release]
+    if: >-
+      always() &&
+      inputs.record_launch != false &&
+      (needs.deploy-eks.outputs.skipped == 'true' ||
+       needs.stamp-release.result == 'failure' ||
+       needs.stamp-release.result == 'cancelled' ||
+       needs.patch-cdn.result == 'failure' ||
+       needs.patch-cdn.result == 'cancelled' ||
+       needs.deploy-eks.result == 'failure' ||
+       needs.deploy-eks.result == 'cancelled' ||
+       needs.promote-latest.result == 'failure' ||
+       needs.promote-latest.result == 'cancelled' ||
+       needs.sync-aliyun.result == 'failure' ||
+       needs.sync-aliyun.result == 'cancelled' ||
+       needs.notify.result == 'failure' ||
+       needs.notify.result == 'cancelled' ||
+       needs.finalize-release.result == 'failure' ||
+       needs.finalize-release.result == 'cancelled')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: finalize-teable-release-${{ inputs.release_record_id || github.run_id }}
+    steps:
+      - name: Checkout code
+        if: inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Settle teable.ai publishing target
+        if: inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+          TARGET_RESULT: ${{ needs.notify.result == 'success' && 'success' || 'failure' }}
+          FAILURE_MESSAGE: teable.ai publishing workflow failed
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$TARGET_RESULT" = "success" ]; then
+            bash .github/scripts/finalize-teable-release.sh
+          else
+            bash .github/scripts/mark-teable-release-failed.sh
+          fi
+
+      - name: Send Feishu failure notification
+        if: always()
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
+          STAMP_RESULT: ${{ needs.stamp-release.result }}
+          PATCH_RESULT: ${{ needs.patch-cdn.result }}
+          DEPLOY_RESULT: ${{ needs.deploy-eks.result }}
+          PROMOTE_RESULT: ${{ needs.promote-latest.result }}
+          ALIYUN_RESULT: ${{ needs.sync-aliyun.result }}
+          LAUNCH_RESULT: ${{ needs.notify.result }}
+          FINALIZE_RESULT: ${{ needs.finalize-release.result }}
+        run: |
+          set -euo pipefail
+          if [ -z "$FEISHU_WEBHOOK_URL" ]; then
+            echo "::error::LARK_BOT_URL is not configured"
+            exit 1
+          fi
+
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          card_payload=$(jq -n \
+            --arg title "teable.ai 发布失败 ${{ inputs.image_tag }}" \
+            --arg stamp "$STAMP_RESULT" \
+            --arg patch "$PATCH_RESULT" \
+            --arg deploy "$DEPLOY_RESULT" \
+            --arg promote "$PROMOTE_RESULT" \
+            --arg aliyun "$ALIYUN_RESULT" \
+            --arg launch "$LAUNCH_RESULT" \
+            --arg finalize "$FINALIZE_RESULT" \
+            --arg url "$run_url" \
+            '{
+              "msg_type": "interactive",
+              "card": {
+                "header": {
+                  "title": {"tag": "plain_text", "content": $title},
+                  "template": "red"
+                },
+                "elements": [
+                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**Release tag**: " + $stamp + "\n**CDN patch**: " + $patch + "\n**EKS 部署**: " + $deploy + "\n**latest 提升**: " + $promote + "\n**Aliyun 同步**: " + $aliyun + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n已回写失败目标；其余目标终结后会自动释放发布锁。\n[查看 Actions](" + $url + ")")}}
+                ]
+              }
+            }')
+          curl -fsS -X POST "$FEISHU_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$card_payload" >/dev/null

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -522,8 +522,32 @@ jobs:
        needs.finalize-release.result == 'cancelled')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: finalize-teable-release-${{ inputs.release_record_id || github.run_id }}
     steps:
+      - name: Checkout code
+        if: inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Settle teable.cn publishing target
+        if: inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: cn
+          TARGET_RESULT: ${{ needs.notify.result == 'success' && 'success' || 'failure' }}
+          FAILURE_MESSAGE: teable.cn publishing workflow failed
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$TARGET_RESULT" = "success" ]; then
+            bash .github/scripts/finalize-teable-release.sh
+          else
+            bash .github/scripts/mark-teable-release-failed.sh
+          fi
+
       - name: Send Feishu failure notification
+        if: always()
         env:
           FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
           ENSURE_RESULT: ${{ needs.ensure-aliyun.result }}
@@ -555,7 +579,7 @@ jobs:
                   "template": "red"
                 },
                 "elements": [
-                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**Aliyun 镜像准备**: " + $ensure + "\n**CDN patch**: " + $patch + "\n**Sealos 部署**: " + $deploy + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n发布锁会保留至过期，请先核对 teable.cn 线上状态。\n[查看 Actions](" + $url + ")")}}
+                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**Aliyun 镜像准备**: " + $ensure + "\n**CDN patch**: " + $patch + "\n**Sealos 部署**: " + $deploy + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n已回写失败目标；其余目标终结后会自动释放发布锁。\n[查看 Actions](" + $url + ")")}}
                 ]
               }
             }')


### PR DESCRIPTION
修复 workflow 已明确失败、Release Publisher 仍等待 6 小时 TTL 的问题。

- 新增锁 ID 校验的失败目标回写脚本
- AI/CN 成功与失败收敛共用 Release 级 concurrency
- 一个环境失败、另一个仍运行时继续持锁
- 所有目标成功/失败后立即恢复 `Released` 并保留已上线环境
- 两个环境都成功仍收敛为 `Launched`
- Launch 已创建但 finalizer 失败时重试成功收敛，不误标失败
- 飞书失败卡片显示所有发布阶段状态

验证：
- actionlint 通过
- shell `bash -n` 通过
- 4 个 mock API 场景通过：CN 成功/AI 失败、AI 先失败等待 CN、CN 后成功解锁、AI 重试成功转 Launched
- 2682 恢复 run 32143043853 已成功。