### PR TITLE
发布前校验锁并限制镜像传输时间

### DIFF
--- a/.github/scripts/validate-teable-publish-lock.sh
+++ b/.github/scripts/validate-teable-publish-lock.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TEABLE_API_TOKEN:?TEABLE_API_TOKEN is required}"
+: "${RELEASE_RECORD_ID:?RELEASE_RECORD_ID is required}"
+: "${PUBLISH_LOCK_ID:?PUBLISH_LOCK_ID is required}"
+: "${TARGET:?TARGET is required}"
+
+if [ "$TARGET" != "ai" ] && [ "$TARGET" != "cn" ]; then
+  echo "Unsupported target: $TARGET"
+  exit 1
+fi
+
+TEABLE_API_BASE="https://app.teable.ai/api"
+RELEASES_TABLE_ID="tblAhVLOxNtvkaF1ii5"
+
+read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-lock.json \
+  "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record/${RELEASE_RECORD_ID}?fieldKeyType=dbFieldName" \
+  -H "Authorization: Bearer ${TEABLE_API_TOKEN}")
+
+if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
+  echo "Failed to read Release publishing metadata: HTTP ${read_http_code}"
+  cat /tmp/release-lock.json
+  exit 1
+fi
+
+release_metadata=$(jq -cer '.fields.Publishing_Metadata | fromjson' /tmp/release-lock.json) || {
+  echo "::error::Release publishing lock is no longer active. Retry ${TARGET} from Release Publisher to acquire a new global lock; do not rerun this Actions run."
+  exit 1
+}
+
+current_lock_id=$(jq -r '.lockId // empty' <<<"$release_metadata")
+current_state=$(jq -r '.state // empty' <<<"$release_metadata")
+target_is_locked=$(jq -r --arg target "$TARGET" \
+  '(.targets // []) | index($target) != null' <<<"$release_metadata")
+already_completed=$(jq -r --arg target "$TARGET" \
+  '(((.launchedTargets // []) + (.completedTargets // [])) | unique) | index($target) != null' \
+  <<<"$release_metadata")
+
+if [ "$already_completed" = "true" ]; then
+  echo "::notice::${TARGET} is already completed for this Release"
+  exit 0
+fi
+
+if [ "$current_state" != "launching" ] || \
+   [ "$current_lock_id" != "$PUBLISH_LOCK_ID" ] || \
+   [ "$target_is_locked" != "true" ]; then
+  echo "::error::Release publishing lock no longer authorizes ${TARGET}. Retry from Release Publisher to acquire a new global lock; do not rerun this Actions run."
+  exit 1
+fi
+
+echo "Validated ${TARGET} publishing lock ${PUBLISH_LOCK_ID}"

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -135,6 +135,19 @@ jobs:
       image_tag: ${{ inputs.image_tag }}
 
     steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Validate teable.ai publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Record start time
         id: start_time
         run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT
@@ -696,11 +709,13 @@ jobs:
 
   notify-failure:
     name: Settle and report teable.ai failure
-    needs: [stamp-release, patch-cdn, deploy-eks, promote-latest, sync-aliyun, notify, finalize-release]
+    needs: [prepare, stamp-release, patch-cdn, deploy-eks, promote-latest, sync-aliyun, notify, finalize-release]
     if: >-
       always() &&
       inputs.record_launch != false &&
-      (needs.deploy-eks.outputs.skipped == 'true' ||
+      (needs.prepare.result == 'failure' ||
+       needs.prepare.result == 'cancelled' ||
+       needs.deploy-eks.outputs.skipped == 'true' ||
        needs.stamp-release.result == 'failure' ||
        needs.stamp-release.result == 'cancelled' ||
        needs.patch-cdn.result == 'failure' ||
@@ -745,6 +760,7 @@ jobs:
         if: always()
         env:
           FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
+          PREFLIGHT_RESULT: ${{ needs.prepare.result }}
           STAMP_RESULT: ${{ needs.stamp-release.result }}
           PATCH_RESULT: ${{ needs.patch-cdn.result }}
           DEPLOY_RESULT: ${{ needs.deploy-eks.result }}
@@ -762,6 +778,7 @@ jobs:
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           card_payload=$(jq -n \
             --arg title "teable.ai 发布失败 ${{ inputs.image_tag }}" \
+            --arg preflight "$PREFLIGHT_RESULT" \
             --arg stamp "$STAMP_RESULT" \
             --arg patch "$PATCH_RESULT" \
             --arg deploy "$DEPLOY_RESULT" \
@@ -778,7 +795,7 @@ jobs:
                   "template": "red"
                 },
                 "elements": [
-                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**Release tag**: " + $stamp + "\n**CDN patch**: " + $patch + "\n**EKS 部署**: " + $deploy + "\n**latest 提升**: " + $promote + "\n**Aliyun 同步**: " + $aliyun + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n已回写失败目标；其余目标终结后会自动释放发布锁。\n[查看 Actions](" + $url + ")")}}
+                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**发布锁预检**: " + $preflight + "\n**Release tag**: " + $stamp + "\n**CDN patch**: " + $patch + "\n**EKS 部署**: " + $deploy + "\n**latest 提升**: " + $promote + "\n**Aliyun 同步**: " + $aliyun + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n已回写失败目标；重试必须从 Release Publisher 重新获取全局锁。\n[查看 Actions](" + $url + ")")}}
                 ]
               }
             }')

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -128,6 +128,23 @@ on:
         required: false
 
 jobs:
+  validate-publish-lock:
+    name: Validate teable.cn publishing lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Validate publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: cn
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
   # teable.cn deploys official release.<id> tags from Aliyun, but Aliyun
   # only receives images at release time (manual-ecs-deploy's sync-aliyun).
   # This job makes the CN launch self-sufficient: if this build was never
@@ -137,8 +154,9 @@ jobs:
   # near-instant when the tags already exist.
   ensure-aliyun:
     name: Ensure release images on Aliyun
+    needs: validate-publish-lock
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Install skopeo
         run: |
@@ -173,7 +191,7 @@ jobs:
           retry_copy() {
             local src="$1" dst="$2" dst_creds="$3"
             for attempt in 1 2 3; do
-              if skopeo copy --all \
+              if timeout --signal=TERM 15m skopeo copy --all \
                   --src-creds="$SRC_CREDS" \
                   --dest-creds="$dst_creds" \
                   "docker://${src}" "docker://${dst}"; then
@@ -190,13 +208,13 @@ jobs:
           # <aliyun prefix>:<the app's release id> at spawn time; it always
           # carries the release tag already (tagged at build time).
           for image in teable-cloud teable-sandbox-cloud teable-sandbox-agent; do
-            if skopeo inspect --raw --creds="$DST_CREDS" \
+            if timeout 60s skopeo inspect --raw --creds="$DST_CREDS" \
                 "docker://${DST_REGISTRY}/${image}:${TAG}" >/dev/null 2>&1; then
               echo "✅ ${image}:${TAG} already on Aliyun"
               continue
             fi
 
-            if ! skopeo inspect --raw --creds="$SRC_CREDS" \
+            if ! timeout 60s skopeo inspect --raw --creds="$SRC_CREDS" \
                 "docker://${SRC_REGISTRY}/${image}:${TAG}" >/dev/null 2>&1; then
               echo "⏫ ${image}:${TAG} not stamped yet, stamping from ${BETA_TAG} on ghcr"
               retry_copy \
@@ -506,11 +524,13 @@ jobs:
 
   notify-failure:
     name: Report teable.cn deploy failure
-    needs: [ensure-aliyun, patch-cdn, deploy, notify, finalize-release]
+    needs: [validate-publish-lock, ensure-aliyun, patch-cdn, deploy, notify, finalize-release]
     if: >-
       always() &&
       inputs.record_launch != false &&
-      (needs.ensure-aliyun.result == 'failure' ||
+      (needs.validate-publish-lock.result == 'failure' ||
+       needs.validate-publish-lock.result == 'cancelled' ||
+       needs.ensure-aliyun.result == 'failure' ||
        needs.ensure-aliyun.result == 'cancelled' ||
        needs.patch-cdn.result == 'failure' ||
        needs.patch-cdn.result == 'cancelled' ||
@@ -550,6 +570,7 @@ jobs:
         if: always()
         env:
           FEISHU_WEBHOOK_URL: ${{ secrets.LARK_BOT_URL }}
+          PREFLIGHT_RESULT: ${{ needs.validate-publish-lock.result }}
           ENSURE_RESULT: ${{ needs.ensure-aliyun.result }}
           PATCH_RESULT: ${{ needs.patch-cdn.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
@@ -565,6 +586,7 @@ jobs:
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           card_payload=$(jq -n \
             --arg title "teable.cn 发布失败 ${{ inputs.image_tag }}" \
+            --arg preflight "$PREFLIGHT_RESULT" \
             --arg ensure "$ENSURE_RESULT" \
             --arg patch "$PATCH_RESULT" \
             --arg deploy "$DEPLOY_RESULT" \
@@ -579,7 +601,7 @@ jobs:
                   "template": "red"
                 },
                 "elements": [
-                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**Aliyun 镜像准备**: " + $ensure + "\n**CDN patch**: " + $patch + "\n**Sealos 部署**: " + $deploy + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n已回写失败目标；其余目标终结后会自动释放发布锁。\n[查看 Actions](" + $url + ")")}}
+                  {"tag": "div", "text": {"tag": "lark_md", "content": ("**发布锁预检**: " + $preflight + "\n**Aliyun 镜像准备**: " + $ensure + "\n**CDN patch**: " + $patch + "\n**Sealos 部署**: " + $deploy + "\n**Launch 记录**: " + $launch + "\n**Release 收敛**: " + $finalize + "\n已回写失败目标；重试必须从 Release Publisher 重新获取全局锁。\n[查看 Actions](" + $url + ")")}}
                 ]
               }
             }')

--- a/.github/workflows/sync-aliyun.yaml
+++ b/.github/workflows/sync-aliyun.yaml
@@ -31,18 +31,33 @@ on:
 env:
   SRC_REGISTRY: ghcr.io/teableio
   DST_REGISTRY: registry.cn-shenzhen.aliyuncs.com/teable
-  MAX_RETRIES: 5
-  RETRY_DELAY: 30
+  MAX_RETRIES: 3
+  RETRY_DELAY: 15
 
 jobs:
   sync:
     name: Sync ${{ inputs.edition }} images
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Install skopeo
         run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if sudo timeout 180s apt-get update \
+                -o Acquire::Retries=3 \
+                -o Acquire::http::Timeout=30 \
+                -o Acquire::https::Timeout=30 && \
+               sudo env DEBIAN_FRONTEND=noninteractive \
+                timeout 180s apt-get install -y skopeo; then
+              exit 0
+            fi
+            echo "::warning::skopeo install attempt ${attempt} failed"
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          echo "::error::skopeo installation failed after 3 attempts"
+          exit 1
 
       - name: Sync images to Aliyun
         env:
@@ -55,7 +70,7 @@ jobs:
             local src="$1" dst="$2" all_flag="$3"
             for attempt in $(seq 1 $MAX_RETRIES); do
               echo "[$attempt/$MAX_RETRIES] Copying ${src} -> ${dst}"
-              if skopeo copy ${all_flag} \
+              if timeout --signal=TERM 15m skopeo copy ${all_flag} \
                   "docker://${src}" "docker://${dst}" \
                   --src-creds="${SRC_CREDS}" \
                   --dest-creds="${DST_CREDS}"; then


### PR DESCRIPTION
修复 Manual Sealos Deploy #423 暴露的两段式故障：

- AI/CN 在任何镜像或部署操作前校验 Release 锁
- 已终结锁的 GitHub rerun 立即失败，并提示从 Release Publisher 重新获取全局锁
- CN 镜像准备总上限从 20 分钟放宽到 60 分钟
- 单次 skopeo copy 限制 15 分钟并重试 3 次，避免总 job 超时中断正在重连的传输
- 公共 sync-aliyun 同步增加相同的安装保护、单次传输上限和 60 分钟 job 上限
- 飞书失败卡片增加锁预检阶段，并明确正确重试入口

验证：
- actionlint 通过
- bash -n 通过
- active/idle/wrong-lock 三种 mock preflight 场景通过
- #423 attempt 3 只重跑 Launch/finalizer 后成功，2696 已 Launched。