### PR TITLE
EE 镜像同步失败时切换 Docker Hub

### DIFF
--- a/.github/workflows/sync-aliyun.yaml
+++ b/.github/workflows/sync-aliyun.yaml
@@ -27,9 +27,12 @@ on:
         required: true
       ALI_DOCKER_PASSWORD:
         required: true
+      DOCKER_HUB_AK:
+        required: false
 
 env:
   SRC_REGISTRY: ghcr.io/teableio
+  EE_SRC_REGISTRY: docker.io/teableio
   DST_REGISTRY: registry.cn-shenzhen.aliyuncs.com/teable
   MAX_RETRIES: 3
   RETRY_DELAY: 15
@@ -62,14 +65,19 @@ jobs:
       - name: Sync images to Aliyun
         env:
           SRC_CREDS: ${{ github.actor }}:${{ secrets.PACKAGES_KEY }}
+          DOCKER_HUB_AK: ${{ secrets.DOCKER_HUB_AK }}
           DST_CREDS: ${{ vars.ALI_DOCKER_USERNAME }}:${{ secrets.ALI_DOCKER_PASSWORD }}
         run: |
           set +e
 
           retry_copy() {
             local src="$1" dst="$2" all_flag="$3"
-            for attempt in $(seq 1 $MAX_RETRIES); do
-              echo "[$attempt/$MAX_RETRIES] Copying ${src} -> ${dst}"
+            local fallback_src="${4:-}" fallback_creds="${5:-}"
+            local primary_attempts="$MAX_RETRIES"
+            [ -n "$fallback_src" ] && primary_attempts=1
+
+            for attempt in $(seq 1 "$primary_attempts"); do
+              echo "[$attempt/$primary_attempts] Copying ${src} -> ${dst}"
               if timeout --signal=TERM 15m skopeo copy ${all_flag} \
                   "docker://${src}" "docker://${dst}" \
                   --src-creds="${SRC_CREDS}" \
@@ -80,7 +88,23 @@ jobs:
               echo "⚠️ Attempt ${attempt} failed. Retrying in ${RETRY_DELAY}s..."
               sleep $RETRY_DELAY
             done
-            echo "❌ FAILED after ${MAX_RETRIES} attempts: ${src}"
+
+            if [ -n "$fallback_src" ]; then
+              for attempt in $(seq 1 "$MAX_RETRIES"); do
+                echo "[$attempt/$MAX_RETRIES] Falling back to ${fallback_src} -> ${dst}"
+                if timeout --signal=TERM 15m skopeo copy ${all_flag} \
+                    "docker://${fallback_src}" "docker://${dst}" \
+                    --src-creds="${fallback_creds}" \
+                    --dest-creds="${DST_CREDS}"; then
+                  echo "✅ Success via fallback: ${fallback_src}"
+                  return 0
+                fi
+                echo "⚠️ Fallback attempt ${attempt} failed. Retrying in ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+              done
+            fi
+
+            echo "❌ FAILED to copy ${src} -> ${dst}"
             return 1
           }
 
@@ -119,6 +143,11 @@ jobs:
                 || FAILED=1
             done
           elif [ "${{ inputs.edition }}" = "ee" ]; then
+            # promote-latest-ee has already copied these exact multi-arch tags
+            # to Docker Hub. Keep GHCR as the primary source for standalone
+            # syncs, then use Docker Hub after one bounded GHCR attempt.
+            FALLBACK_CREDS=""
+            [ -n "$DOCKER_HUB_AK" ] && FALLBACK_CREDS="teableio:${DOCKER_HUB_AK}"
             IMAGES=("teable" "teable-sandbox")
             SUFFIXES=("" "-ee")
 
@@ -126,10 +155,14 @@ jobs:
               for suffix in "${SUFFIXES[@]}"; do
                 for tag in "${TAGS[@]}"; do
                   [ -n "$tag" ] || continue
+                  fallback_src=""
+                  [ -n "$FALLBACK_CREDS" ] && fallback_src="${EE_SRC_REGISTRY}/${image}${suffix}:${tag}"
                   retry_copy \
                     "${SRC_REGISTRY}/${image}${suffix}:${tag}" \
                     "${DST_REGISTRY}/${image}${suffix}:${tag}" \
                     "--all" \
+                    "$fallback_src" \
+                    "$FALLBACK_CREDS" \
                     || FAILED=1
                 done
               done
@@ -143,10 +176,14 @@ jobs:
             for tag in "${TAGS[@]}"; do
               [ -n "$tag" ] || continue
               [ "$tag" = "latest" ] && continue
+              fallback_src=""
+              [ -n "$FALLBACK_CREDS" ] && fallback_src="${EE_SRC_REGISTRY}/teable-sandbox-agent:${tag}"
               retry_copy \
                 "${SRC_REGISTRY}/teable-sandbox-agent:${tag}" \
                 "${DST_REGISTRY}/teable-sandbox-agent:${tag}" \
                 "--all" \
+                "$fallback_src" \
+                "$FALLBACK_CREDS" \
                 || FAILED=1
             done
           fi


### PR DESCRIPTION
为 EE→Aliyun 同步增加独立镜像源 fallback：

- GHCR 仍是主源，保持 standalone/manual sync 的原有契约
- GHCR 单次 15 分钟失败后，不再对同一 EOF 路径重复三次
- 若 `DOCKER_HUB_AK` 可用，改从前序 promotion 已完成的 Docker Hub 多架构 tag 重试
- Cloud 同步继续只使用 GHCR，不改变现有行为
- Docker Hub fallback 仍受 15 分钟单次上限和 3 次重试约束

背景：2696 旧 run 对同一 GHCR blob 连续 EOF 43 分钟；PR #100 后的新 run 能在 15 分钟终止连接并于第二次尝试成功。

验证：actionlint 和 diff check 通过；Release Note run 32153631987 成功。