### PR TITLE
重跑发布任务时逐步复验全局锁

### DIFF
--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -126,6 +126,10 @@ on:
 # The only shared mutable state this workflow touches cross-run is the EKS
 # deployments; deploy-eks guards those with a deploy-epoch annotation CAS
 # instead (older attempt refuses to overwrite a newer one).
+#
+# GitHub's "re-run failed jobs" reuses successful upstream jobs from the
+# previous attempt. Every job that can mutate images or production therefore
+# revalidates the Release lock in its own steps; prepare alone is not enough.
 jobs:
   prepare:
     name: Prepare Deployment
@@ -165,6 +169,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.ai publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
         with:
@@ -230,6 +247,18 @@ jobs:
       ECR_IMAGE: 649941507946.dkr.ecr.us-west-2.amazonaws.com/teable/teable-cloud
 
     steps:
+      - name: Checkout deploy and lock validation scripts
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.ai publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -272,10 +301,6 @@ jobs:
             fi
           fi
           echo "promoted=false" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout deploy scripts
-        if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false'
-        uses: actions/checkout@v4
 
       - name: Build patch layer
         if: steps.existing.outputs.exists == 'false' && steps.promote.outputs.promoted == 'false'
@@ -353,6 +378,19 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.ai publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Configure AWS credentials (OIDC, namespace-scoped role)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -564,6 +602,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.ai publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ai
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
         with:
@@ -611,6 +662,9 @@ jobs:
     with:
       edition: cloud
       tags: "latest,${{ inputs.image_tag }}"
+      release_record_id: ${{ inputs.release_record_id }}
+      publish_lock_id: ${{ inputs.publish_lock_id }}
+      publish_target: ai
     secrets: inherit
 
   # Preheat CN sandbox-agent nodes as soon as the agent tag lands on Aliyun.

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -127,6 +127,9 @@ on:
       SEALOS_OBJECTSTORAGE_SECRET_KEY:
         required: false
 
+# GitHub's "re-run failed jobs" reuses successful upstream jobs from the
+# previous attempt. Keep the initial fast-fail job, but every job that can
+# mutate images or production must also revalidate the lock in its own steps.
 jobs:
   validate-publish-lock:
     name: Validate teable.cn publishing lock
@@ -158,6 +161,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.cn publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: cn
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Install skopeo
         run: |
           set -euo pipefail
@@ -262,6 +278,18 @@ jobs:
       ALIYUN_IMAGE: registry.cn-shenzhen.aliyuncs.com/teable/teable-cloud
 
     steps:
+      - name: Checkout deploy and lock validation scripts
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.cn publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: cn
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Login to Aliyun container registry
         uses: docker/login-action@v3
         with:
@@ -282,10 +310,6 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Checkout deploy scripts
-        if: steps.existing.outputs.exists == 'false'
-        uses: actions/checkout@v4
 
       - name: Build patch layer
         if: steps.existing.outputs.exists == 'false'
@@ -367,6 +391,19 @@ jobs:
       image_tag: ${{ inputs.image_tag }}
 
     steps:
+      - name: Checkout lock validation script
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        uses: actions/checkout@v4
+
+      - name: Revalidate teable.cn publishing lock
+        if: inputs.record_launch != false && inputs.release_record_id != '' && inputs.publish_lock_id != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: cn
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Record start time
         id: start_time
         run: echo "start=$(date +%s)" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync-aliyun.yaml
+++ b/.github/workflows/sync-aliyun.yaml
@@ -22,12 +22,26 @@ on:
       tags:
         required: true
         type: string
+      release_record_id:
+        required: false
+        type: string
+        default: ''
+      publish_lock_id:
+        required: false
+        type: string
+        default: ''
+      publish_target:
+        required: false
+        type: string
+        default: ''
     secrets:
       PACKAGES_KEY:
         required: true
       ALI_DOCKER_PASSWORD:
         required: true
       DOCKER_HUB_AK:
+        required: false
+      TEABLE_API_TOKEN:
         required: false
 
 env:
@@ -43,6 +57,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - name: Checkout lock validation script
+        if: inputs.release_record_id != '' && inputs.publish_lock_id != '' && inputs.publish_target != ''
+        uses: actions/checkout@v4
+
+      - name: Revalidate publishing lock
+        if: inputs.release_record_id != '' && inputs.publish_lock_id != '' && inputs.publish_target != ''
+        env:
+          TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
+          RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
+          TARGET: ${{ inputs.publish_target }}
+        run: bash .github/scripts/validate-teable-publish-lock.sh
+
       - name: Install skopeo
         run: |
           set -euo pipefail


### PR DESCRIPTION
修复 GitHub `re-run failed jobs` 复用已成功 upstream job、从而绕过旧 preflight 锁校验的问题。

- CN 的 Aliyun 镜像准备、CDN patch、Sealos deploy 在自身 job 首步重新校验 CN 锁
- AI 的 release stamp、CDN patch、EKS deploy、latest promotion 在自身 job 首步重新校验 AI 锁
- cloud `sync-aliyun` reusable workflow 接收可选锁参数并在同步前复验
- rollback 和 Release Note 等 `record_launch: false`/无锁调用保持原行为
- Launch 创建脚本原有的最终锁校验继续保留

事故证据：Manual Sealos Deploy #426 attempt 1 的锁校验成功后发布失败并释放锁；attempt 2 的 failed-jobs rerun 复用了 attempt 1 的绿色校验结果，仍执行了 Sealos deploy，最终只在 Launch 回写时被拒绝。

恢复结果：2715 CN 实际 rollout 已成功，仅补写 Launch/finalizer；attempt 4 成功，Release 已 Launched。

验证：actionlint 全量 workflow 校验和 git diff --check 通过。