### PR TITLE
双区域上线后标记全部覆盖版本

### DIFF
--- a/.github/scripts/finalize-teable-release.sh
+++ b/.github/scripts/finalize-teable-release.sh
@@ -14,6 +14,43 @@ fi
 TEABLE_API_BASE="https://app.teable.ai/api"
 RELEASES_TABLE_ID="tblAhVLOxNtvkaF1ii5"
 
+mark_covered_releases_launched() {
+  local covered_release_ids update_payload update_http_code
+  covered_release_ids=$(printf '%s' "${RELATED_RELEASE_RECORD_IDS:-}" | jq -Rc \
+    --arg target "$RELEASE_RECORD_ID" \
+    'split(",")
+     | map(gsub("^\\s+|\\s+$"; ""))
+     | . + [$target]
+     | map(select(test("^rec[A-Za-z0-9]+$")))
+     | unique')
+  update_payload=$(jq -n \
+    --argjson recordIds "$covered_release_ids" \
+    '{
+      "fieldKeyType": "dbFieldName",
+      "typecast": true,
+      "records": ($recordIds | map({
+        "id": .,
+        "fields": {
+          "status": "Launched",
+          "Publishing_Metadata": null
+        }
+      }))
+    }')
+  update_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-update.json -X PATCH \
+    "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record" \
+    -H "Authorization: Bearer ${TEABLE_API_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d "$update_payload")
+
+  if [ "$update_http_code" -lt 200 ] || [ "$update_http_code" -ge 300 ]; then
+    echo "Failed to mark covered Releases as Launched: HTTP ${update_http_code}"
+    cat /tmp/release-update.json
+    exit 1
+  fi
+
+  echo "Marked covered Releases ${covered_release_ids} as Launched"
+}
+
 read_http_code=$(curl -sS -w "%{http_code}" -o /tmp/release-lock.json \
   "${TEABLE_API_BASE}/table/${RELEASES_TABLE_ID}/record/${RELEASE_RECORD_ID}?fieldKeyType=dbFieldName" \
   -H "Authorization: Bearer ${TEABLE_API_TOKEN}")
@@ -24,10 +61,11 @@ if [ "$read_http_code" -lt 200 ] || [ "$read_http_code" -ge 300 ]; then
   exit 1
 fi
 
-release_metadata=$(jq -cer '.fields.Publishing_Metadata | fromjson' /tmp/release-lock.json) || {
+release_metadata=$(jq -cer '.fields.Publishing_Metadata | strings | try fromjson' /tmp/release-lock.json) || {
   current_status=$(jq -r '.fields.status // empty' /tmp/release-lock.json)
   if [ "$current_status" = "Launched" ]; then
-    echo "Release is already fully launched"
+    mark_covered_releases_launched
+    echo "Release was already fully launched; coverage reconciled"
     exit 0
   fi
   echo "Release publishing metadata is missing or invalid"
@@ -59,8 +97,9 @@ has_pending_lock_target=$(jq -r --argjson terminal "$terminal_targets" \
   <<<"$completed_metadata")
 
 if [ "$all_launched" = "true" ]; then
-  release_status="Launched"
-  publishing_metadata="null"
+  mark_covered_releases_launched
+  echo "Launched targets: ${launched_targets}"
+  exit 0
 elif [ "$has_pending_lock_target" = "true" ]; then
   release_status="Launching"
   publishing_metadata=$(jq -Rn --arg value "$completed_metadata" '$value')

--- a/.github/workflows/manual-ecs-deploy.yml
+++ b/.github/workflows/manual-ecs-deploy.yml
@@ -757,6 +757,7 @@ jobs:
         env:
           TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
           RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
           TARGET: ai
         run: bash .github/scripts/finalize-teable-release.sh
@@ -798,6 +799,7 @@ jobs:
         env:
           TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
           RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
           TARGET: ai
           TARGET_RESULT: ${{ needs.notify.result == 'success' && 'success' || 'failure' }}

--- a/.github/workflows/manual-sealos-deploy.yaml
+++ b/.github/workflows/manual-sealos-deploy.yaml
@@ -555,6 +555,7 @@ jobs:
         env:
           TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
           RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
           TARGET: cn
         run: bash .github/scripts/finalize-teable-release.sh
@@ -591,6 +592,7 @@ jobs:
         env:
           TEABLE_API_TOKEN: ${{ secrets.TEABLE_API_TOKEN }}
           RELEASE_RECORD_ID: ${{ inputs.release_record_id }}
+          RELATED_RELEASE_RECORD_IDS: ${{ inputs.related_release_record_ids }}
           PUBLISH_LOCK_ID: ${{ inputs.publish_lock_id }}
           TARGET: cn
           TARGET_RESULT: ${{ needs.notify.result == 'success' && 'success' || 'failure' }}


### PR DESCRIPTION
恢复 Release 的聚合上线语义：`Launched` 表示该 Release 已被实际双区域上线版本覆盖，而不只是它自身被选为目标。

- AI/CN finalizer 都接收发布时冻结的 `related_release_record_ids`
- 单区域完成仍只更新当前 Release 的发布进度
- AI 和 CN 都完成后，批量把目标及全部 Related Releases 标记为 `Launched`
- 同时清理这些已上线 Release 的旧 Publishing Metadata，避免继续显示失败或进入待发布列表
- finalizer 重跑时会幂等补齐覆盖状态，即使目标 Release 已经是 `Launched`
- record ID 去重并过滤非法值

根因：现有 finalizer 仅 PATCH `RELEASE_RECORD_ID`，导致 2715 发布覆盖的 2712、2711、2710、2706、2700、2697 仍显示 `Released`。

验证：bash -n、actionlint 全量 workflow、diff check，以及单区域/双区域/已完成幂等三类 mock API 测试通过。